### PR TITLE
fix: harden git helpers and tooling

### DIFF
--- a/wgx
+++ b/wgx
@@ -1463,8 +1463,8 @@ _pkg_json_set_ver(){
     local tmp="${pj}.tmp"
     awk -v ver="$ver" '
       BEGIN{done=0}
-      !done && /"version"[[:space:]]*:/ {
-        sub(/"version"[[:space:]]*:[[:space:]]*"[^"]*"/, "\"version\": \"" ver "\""); done=1
+      !done && /^[[:space:]]*"version"[[:space:]]*:/ {
+        sub(/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"[^"]*"/, "\"version\": \"" ver "\""); done=1
       }
       { print }
     ' "$pj" > "$tmp" && mv "$tmp" "$pj"


### PR DESCRIPTION
## Summary
- harden git helper routines to correctly parse remotes and detect in-progress operations
- improve linting fallbacks, package.json version updates, and Termux helper return codes for portability
- ensure ancillary utilities honor offline mode and avoid brittle shell constructs

## Testing
- bash -n wgx
- ./wgx --offline doctor

------
https://chatgpt.com/codex/tasks/task_e_68cfc56e3178832ca851efa4e502eec0