### PR TITLE
Pin shfmt download URL to v3.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y shellcheck
-          curl -sSLo /usr/local/bin/shfmt https://github.com/mvdan/sh/releases/latest/download/shfmt_linux_amd64
+          curl -sSLo /usr/local/bin/shfmt https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_linux_amd64
           chmod +x /usr/local/bin/shfmt
       - name: Run linters
         run: |


### PR DESCRIPTION
## Summary
- download a specific shfmt release instead of the moving latest tag to ensure a valid binary

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfcdc28f20832c859a0eaa6c0b6bf0