### PR TITLE
Normalize CLI helper fallbacks

### DIFF
--- a/lib/core.bash
+++ b/lib/core.bash
@@ -14,9 +14,11 @@ _warn() {
   printf '⚠️  %s\n' "$*" >&2
 }
 
-info() {
-  printf '• %s\n' "$*"
-}
+if ! type -t info >/dev/null 2>&1; then
+  info() {
+    printf '• %s\n' "$*"
+  }
+fi
 
 if ! type -t ok >/dev/null 2>&1; then
   ok() {


### PR DESCRIPTION
## Summary
- introduce canonical helper wrappers for ok, warn, die, and info output in `lib/core.bash`
- guard the public helper definitions with type checks to avoid duplicate redefinitions when sourcing scripts
- keep the existing log_* helpers while routing them through consistent stderr-safe printf usage

## Testing
- not run (bats is not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7ff29a608832cb778611e2fb6303c