### PR TITLE
Fix reload test project root detection

### DIFF
--- a/tests/reload.bats
+++ b/tests/reload.bats
@@ -15,8 +15,10 @@ setup() {
   mkdir -p ../remote && (cd ../remote && git init --bare >/dev/null)
   git remote add origin ../remote
   git push -u origin main >/dev/null
-  # WGX_DIR auf Projekt-Root setzen (eine Ebene höher annehmen)
-  export WGX_DIR="$(cd .. && pwd)"
+  # WGX_DIR auf das Projekt-Root setzen (eine Ebene oberhalb des Testverzeichnisses)
+  local project_root
+  project_root="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  export WGX_DIR="$project_root"
   export PATH="$WGX_DIR:$PATH"
 }
 


### PR DESCRIPTION
## Summary
- ensure the reload bats test resolves the project root via BATS_TEST_DIRNAME so it can invoke the real wgx script

## Testing
- not run (bats unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8053ae27c832cbd405b27ccdc933c