### PR TITLE
Fix quoting for test command invocation

### DIFF
--- a/cmd/test.bash
+++ b/cmd/test.bash
@@ -90,5 +90,5 @@ test_cmd() {
 }
 
 wgx_command_main(){
-  test_cmd "$@
+  test_cmd "$@"
 }


### PR DESCRIPTION
## Summary
- close the double-quoted argument expansion when calling `test_cmd` in `cmd/test.bash`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8ddcd9f00832caac08a3d1f3cd494