### PR TITLE
Fix unterminated string in wgx test command

### DIFF
--- a/cmd/test.bash
+++ b/cmd/test.bash
@@ -90,5 +90,5 @@ test_cmd() {
 }
 
 wgx_command_main(){
-  test_cmd "$@
+  test_cmd "$@"
 }


### PR DESCRIPTION
## Summary
- close the unterminated quoted string in cmd/test.bash so arguments forward correctly

## Testing
- shellcheck cmd/test.bash *(fails: shellcheck not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e8128fe0832cade0fe85458bd7a1