### PR TITLE
Fix release cleanup arithmetic and add reload test diagnostics

### DIFF
--- a/archiv/wgx
+++ b/archiv/wgx
@@ -1576,7 +1576,7 @@ release_cmd() {
   [[ "$VERSION" != v* ]] && VERSION="v$VERSION"
 
   local notes_text="" notes_file="" _cleanup_notes=0
-  _release_cleanup() { (( _cleanup_notes )) && [[ -n "$notes_file" && -f "$notes_file" ]] && rm -f "$notes_file"; }
+  _release_cleanup() { ((_cleanup_notes)) && [[ -n "$notes_file" && -f "$notes_file" ]] && rm -f "$notes_file"; }
   trap '_release_cleanup' EXIT
 
   if [[ "$NOTES" == "auto" ]]; then

--- a/tests/reload.bats
+++ b/tests/reload.bats
@@ -30,6 +30,14 @@ teardown() {
 @test "reload performs hard reset and clean" {
   # lokale Änderung
   echo "local" > local.txt
+  # Debug-Ausgabe, falls das Setup im CI schiefgeht
+  echo "WGX_DIR: ${WGX_DIR:-<unset>}"
+  if [ -e "$WGX_DIR/wgx" ]; then
+    ls -l "$WGX_DIR/wgx"
+  else
+    echo "wgx script missing at $WGX_DIR/wgx"
+  fi
+
   # rufe wgx reload (aus dem echten Projekt)
   run "$WGX_DIR/wgx" reload
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- fix the arithmetic evaluation in the release cleanup helper to avoid syntax errors
- add diagnostic output to the reload integration test to help debug failures in CI

## Testing
- not run (bats is not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8e8802794832cbac395b5bd55e843