### PR TITLE
Set up strict CI for Bash and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,18 @@ jobs:
       - name: shfmt (check)
         run: |
           # Fail if any .sh/.bash not formatted
-          files=$(git ls-files '*.sh' '*.bash' | tr '\n' ' ')
-          if [ -n "$files" ]; then
-            shfmt -d $files
+          readarray -t files < <(git ls-files '*.sh' '*.bash')
+          if [ "${#files[@]}" -gt 0 ]; then
+            shfmt -d "${files[@]}"
           else
             echo "No shell files."
           fi
 
       - name: shellcheck
         run: |
-          files=$(git ls-files '*.sh' '*.bash' | tr '\n' ' ')
-          if [ -n "$files" ]; then
-            shellcheck -S style $files
+          readarray -t files < <(git ls-files '*.sh' '*.bash')
+          if [ "${#files[@]}" -gt 0 ]; then
+            shellcheck -S style "${files[@]}"
           else
             echo "No shell files."
           fi


### PR DESCRIPTION
## Summary
- enforce bash formatting, linting, and bats tests without soft failures
- add separate docs lint job covering markdown style and link checking

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d909da395c832ca4a94efa409e1dde