### PR TITLE
Harmonize editor configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,24 +1,12 @@
-# Top-level EditorConfig file
 root = true
 
 [*]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
+indent_style = space
+indent_size = 2
 trim_trailing_whitespace = true
 
-[*.{sh,bash}]
-indent_style = space
-indent_size = 2
-
-[*.{js,ts,json,yml,yaml}]
-indent_style = space
-indent_size = 2
-
-[*.py]
-indent_style = space
-indent_size = 4
-
-[*.rs]
-indent_style = space
-indent_size = 4
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary
- replace the repository EditorConfig with a unified standard for LF line endings, UTF-8 encoding, and two-space indentation
- disable trailing whitespace trimming specifically for Markdown files while keeping trimming enabled elsewhere

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d910b28818832c814d92ebe8b86071