### PR TITLE
Fix markdownlint formatting issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,24 +4,29 @@
 Keep changes small, portable and covered by tests.
 
 ## Ground rules
+
 - **Language:** English for code, docs and commit messages (helps tooling/Copilot).
 - **Portability:** Do not break Termux/WSL/Codespaces. No GNU-only flags unless guarded.
 - **Safety:** `set -euo pipefail` in all scripts; no silent failures.
 - **Help:** Every command must support `-h|--help`.
 
 ## Dev setup
+
 - Use the Dev Container. It ships `shellcheck`, `shfmt`, `bats`.
 - Local dev outside container: install those tools manually.
 
 ## Lint & tests
+
 - Format check: `shfmt -d`.
 - Lint: `shellcheck -f gcc`.
 - Tests: place Bats tests under `tests/` and run `bats -r tests`.
 
 ## Commits & PRs
+
 - Conventional-ish prefix: `feat|fix|docs|refactor|chore(wgx:subcmd): ...`
 - Keep PRs focused; include “How tested”.
 
 ## Definition of done
+
 - CI green (bash_lint_test).
 - For new/changed commands: help text + Bats test exist.

--- a/README.md
+++ b/README.md
@@ -64,15 +64,19 @@ Destruktiv: setzt den Workspace hart auf `origin/$WGX_BASE` zurück (`git reset 
 └─ docs/                # Handbücher, ADRs
 ```
 
-Der eigentliche Dispatcher liegt unter `cli/wgx`. Alle Subcommands werden über die Dateien im Ordner `cmd/` geladen und greifen dabei auf die Bibliotheken in `lib/` zurück. Wiederkehrende Helfer (Logging, Git-Hilfen, Environment-Erkennung usw.) sind im Kernmodul `lib/core.bash` gebündelt.
+Der eigentliche Dispatcher liegt unter `cli/wgx`.
+Alle Subcommands werden über die Dateien im Ordner `cmd/` geladen und greifen dabei auf die Bibliotheken in `lib/` zurück.
+Wiederkehrende Helfer (Logging, Git-Hilfen, Environment-Erkennung usw.) sind im Kernmodul `lib/core.bash` gebündelt.
 
 ## Konfiguration
 
-Standardwerte liegen unter `etc/config.example`. Beim ersten Lauf von `wgx init` werden die Werte nach `~/.config/wgx/config` kopiert und können dort projektspezifisch angepasst werden.
+Standardwerte liegen unter `etc/config.example`.
+Beim ersten Lauf von `wgx init` werden die Werte nach `~/.config/wgx/config` kopiert und können dort projektspezifisch angepasst werden.
 
 ## Tests
 
-Automatisierte Tests werden über `tests/` organisiert (z. B. mit [Bats](https://bats-core.readthedocs.io/)). Ergänzende Checks kannst du via `wgx selftest` starten.
+Automatisierte Tests werden über `tests/` organisiert (z. B. mit [Bats](https://bats-core.readthedocs.io/)).
+Ergänzende Checks kannst du via `wgx selftest` starten.
 
 ## Architecture Note — Modular Only
 Seit 2025-09-25 ist die modulare Struktur verbindlich (`cli/`, `cmd/`, `lib/`, `etc/`, `modules/`).


### PR DESCRIPTION
## Summary
- add missing blank lines around headings and lists in the contributing guide
- reflow long README paragraphs to satisfy markdownlint line length requirements

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68d99497da78832c846c9698e5aceae9