### PR TITLE
Fix status module info detection and markdown lint warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,14 @@ wgx --list 2>/dev/null || wgx commands 2>/dev/null || ls -1 cmd/
 ## Commands
 
 ### reload
+
 Destruktiv: setzt den Workspace hart auf `origin/$WGX_BASE` zurück (`git reset --hard` + `git clean -fdx`).
 
 **Alias**: `sync-remote`.
 
 ## Repository-Layout
 
-```
+```text
 .
 ├─ cli/                 # Einstieg: ./cli/wgx (Dispatcher)
 ├─ cmd/                 # EIN Subcommand = EINE Datei
@@ -71,7 +72,8 @@ Wiederkehrende Helfer (Logging, Git-Hilfen, Environment-Erkennung usw.) sind im 
 ## Konfiguration
 
 Standardwerte liegen unter `etc/config.example`.
-Beim ersten Lauf von `wgx init` werden die Werte nach `~/.config/wgx/config` kopiert und können dort projektspezifisch angepasst werden.
+Beim ersten Lauf von `wgx init` werden die Werte nach `~/.config/wgx/config` kopiert.
+Anschließend kannst du sie dort projektspezifisch anpassen.
 
 ## Tests
 

--- a/docs/archive/wgx_monolith_20250925T130147Z.md
+++ b/docs/archive/wgx_monolith_20250925T130147Z.md
@@ -1,3 +1,4 @@
+```bash
 #!/usr/bin/env bash
 # wgx – Weltgewebe CLI · Termux/WSL/macOS/Linux · origin-first
 # Version: v2.0.2
@@ -953,3 +954,4 @@ case "$SUB" in
   ""|help|-h|--help) usage;;
   *) die "Unbekanntes Kommando: $SUB";;
 esac
+```

--- a/modules/status.bash
+++ b/modules/status.bash
@@ -49,9 +49,21 @@ status_cmd() {
     done
   fi
   if (( ! info_present )); then
-    [[ -d web ]] && echo "▶ Web-Verzeichnis: web"
-    [[ -d api ]] && echo "▶ API-Verzeichnis: api"
-    [[ -d crates ]] && echo "▶ crates vorhanden"
+    local fallback_present=0
+    if [[ -d web ]]; then
+      echo "▶ Web-Verzeichnis: web"
+      fallback_present=1
+    fi
+    if [[ -d api ]]; then
+      echo "▶ API-Verzeichnis: api"
+      fallback_present=1
+    fi
+    if [[ -d crates ]]; then
+      echo "▶ crates vorhanden"
+      fallback_present=1
+    fi
+
+    (( fallback_present )) && info_present=1
   fi
 
   # OFFLINE?


### PR DESCRIPTION
## Summary
- ensure the status module flags default directories as detected so the info check stops failing
- wrap the archived monolith script in a fenced bash block to satisfy markdownlint
- add spacing, language hints, and wrap a long sentence in the README for markdownlint compliance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d99efac364832c84eed2197aee8405