### PR TITLE
Fix help command list formatting

### DIFF
--- a/lib/core.bash
+++ b/lib/core.bash
@@ -138,7 +138,7 @@ Usage:
   wgx <command> [args]
 
 Commands:
-"$(wgx_print_command_list)"
+$(wgx_print_command_list)
 
 Env:
   WGX_BASE       Basis-Branch für reload (default: main)


### PR DESCRIPTION
## Summary
- remove the stray quotation marks around the dynamically generated command list in the help output so commands render on separate lines

## Testing
- bats -r tests *(fails: bats not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9fdd1f974832cb87d15204f4c6ecd