### PR TITLE
Fix markdownlint violations in docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ wgx --list 2>/dev/null || wgx commands 2>/dev/null || ls -1 cmd/
 
 - Open in VS Code → “Reopen in Container”
 - Run CI locally:
+
   ```bash
   shfmt -d $(git ls-files '*.sh' '*.bash')
   shellcheck -S style $(git ls-files '*.sh' '*.bash')
@@ -81,5 +82,6 @@ Automatisierte Tests werden über `tests/` organisiert (z. B. mit [Bats](https
 Ergänzende Checks kannst du via `wgx selftest` starten.
 
 ## Architecture Note — Modular Only
+
 Seit 2025-09-25 ist die modulare Struktur verbindlich (`cli/`, `cmd/`, `lib/`, `etc/`, `modules/`).
 Der alte Monolith wurde archiviert: `docs/archive/wgx_monolith_*.md`.

--- a/docs/archive/wgx_monolith_20250925T130147Z.md
+++ b/docs/archive/wgx_monolith_20250925T130147Z.md
@@ -65,7 +65,11 @@ case "$(uname -s 2>/dev/null || echo x)" in
   *)      PLATFORM="linux" ;;
 esac
 is_wsl(){ uname -r 2>/dev/null | grep -qiE 'microsoft|wsl2?'; }
-is_termux(){ [[ "${PREFIX-}" == *"/com.termux/"* ]] && return 0; command -v termux-setup-storage >/dev/null 2>&1 && return 0; return 1; }
+is_termux(){
+  [[ "${PREFIX-}" == *"/com.termux/"* ]] && return 0
+  command -v termux-setup-storage >/dev/null 2>&1 && return 0
+  return 1
+}
 is_codespace(){ [[ -n "${CODESPACE_NAME-}" ]]; }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -74,18 +78,54 @@ is_codespace(){ [[ -n "${CODESPACE_NAME-}" ]]; }
 is_git_repo(){ git rev-parse --is-inside-work-tree >/dev/null 2>&1; }
 require_repo(){ has git || die "git nicht installiert."; is_git_repo || die "Nicht im Git-Repo."; }
 
-_root_resolve(){ local here="$1"; if has greadlink; then greadlink -f "$here"
-elif has readlink && readlink -f / >/dev/null 2>&1; then readlink -f "$here"
-else local target="$here" link base; while link="$(readlink "$target" 2>/dev/null)"; do
-case "$link" in /*) target="$link";; *) base="$(cd "$(dirname "$target")" && pwd -P)"; target="$base/$link";; esac; done; printf "%s" "$target"; fi; }
+_root_resolve(){
+  local here="$1"
+  if has greadlink; then
+    greadlink -f "$here"
+  elif has readlink && readlink -f / >/dev/null 2>&1; then
+    readlink -f "$here"
+  else
+    local target="$here" link base
+    while link="$(readlink "$target" 2>/dev/null)"; do
+      case "$link" in
+        /*)
+          target="$link"
+          ;;
+        *)
+          base="$(cd "$(dirname "$target")" && pwd -P)"
+          target="$base/$link"
+          ;;
+      esac
+    done
+    printf "%s" "$target"
+  fi
+}
 
-ROOT(){ local here; here="$(_root_resolve "${BASH_SOURCE[0]}")"; local fallback; fallback="$(cd "$(dirname "$here")/.." && pwd -P)"
-local r; r="$(git -C "${PWD}" rev-parse --show-toplevel 2>/dev/null || true)"
-[[ -n "$r" ]] && printf "%s" "$r" || printf "%s" "$fallback"; }
+ROOT(){
+  local here
+  here="$(_root_resolve "${BASH_SOURCE[0]}")"
+  local fallback
+  fallback="$(cd "$(dirname "$here")/.." && pwd -P)"
+  local r
+  r="$(git -C "${PWD}" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "$r" ]]; then
+    printf "%s" "$r"
+  else
+    printf "%s" "$fallback"
+  fi
+}
 
-if r="$(git rev-parse --show-toplevel 2>/dev/null)"; then ROOT_DIR="$r"; else here="${BASH_SOURCE[0]}"; base="$(cd "$(dirname "$here")" && pwd -P)"
-if [[ "$(basename "$base")" == "wgx" && "$(basename "$(dirname "$base")")" == "cli" ]]; then ROOT_DIR="$(cd "$base/../.." && pwd -P)"
-else ROOT_DIR="$(cd "$base/.." && pwd -P)"; fi; fi
+if r="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  ROOT_DIR="$r"
+else
+  here="${BASH_SOURCE[0]}"
+  base="$(cd "$(dirname "$here")" && pwd -P)"
+  if [[ "$(basename "$base")" == "wgx" && "$(basename "$(dirname "$base")")" == "cli" ]]; then
+    ROOT_DIR="$(cd "$base/../.." && pwd -P)"
+  else
+    ROOT_DIR="$(cd "$base/.." && pwd -P)"
+  fi
+fi
 
 # CONFIG (.wgx.conf)
 if [[ -f "$ROOT_DIR/.wgx.conf" ]]; then
@@ -93,7 +133,8 @@ if [[ -f "$ROOT_DIR/.wgx.conf" ]]; then
     k="$(trim "$k")"; [[ -z "$k" || "$k" =~ ^# ]] && continue
     if [[ "$k" =~ ^[A-Z0-9_]+$ ]]; then
       v="${v%$'\r'}"
-      [[ "$v" == *'$('* || "$v" == *'`'* || "$v" == *$'\0'* ]] && { warn ".wgx.conf: unsicherer Wert für $k ignoriert"; continue; }
+      [[ "$v" == *'$('* || "$v" == *'`'* || "$v" == *$'\0'* ]] \
+        && { warn ".wgx.conf: unsicherer Wert für $k ignoriert"; continue; }
       printf -v _sanitized "%s" "$v"; declare -x "$k=$_sanitized"
     else
       warn ".wgx.conf: ungültiger Schlüssel '$k' ignoriert"
@@ -113,14 +154,28 @@ file_size_bytes(){ local f="$1" sz=0
 git_supports_magic(){ git -C "$1" ls-files -z -- ':(exclude)node_modules/**' >/dev/null 2>&1; }
 
 mktemp_portable(){ local p="${1:-wgx}"
-  if has mktemp; then mktemp -t "${p}.XXXXXX" 2>/dev/null || { local f="${TMPDIR:-/tmp}/${p}.$$.tmp"; : > "$f" && printf "%s" "$f"; }
-  else local f="${TMPDIR:-/tmp}/${p}.$(date +%s).$$"; : > "$f" || die "tmp fehlgeschlagen"; printf "%s" "$f"; fi; }
+  if has mktemp; then
+    mktemp -t "${p}.XXXXXX" 2>/dev/null || {
+      local f="${TMPDIR:-/tmp}/${p}.$$.tmp"
+      : > "$f" && printf "%s" "$f"
+    }
+  else
+    local f="${TMPDIR:-/tmp}/${p}.$(date +%s).$$"
+    : > "$f" || die "tmp fehlgeschlagen"
+    printf "%s" "$f"
+  fi
+}
 
 now_ts(){ date +"%Y-%m-%d %H:%M"; }
 
 maybe_sign_flag(){ case "${WGX_SIGNING}" in
   off) return 1;; ssh) has git && git config --get gpg.format 2>/dev/null | grep -qi 'ssh' && echo "-S" || return 1;;
-  gpg) has gpg && echo "-S" || return 1;; auto) git config --get user.signingkey >/dev/null 2>&1 && echo "-S" || return 1;;
+  gpg)
+    has gpg && echo "-S" || return 1
+    ;;
+  auto)
+    git config --get user.signingkey >/dev/null 2>&1 && echo "-S" || return 1
+    ;;
   *) return 1;; esac; }
 
 with_timeout(){ local t="${TIMEOUT:-0}"; (( NOTIMEOUT )) && exec "$@"
@@ -161,13 +216,27 @@ git_ahead_behind(){ local b="${1:-$(git_branch)}"
   local behind=0 ahead=0 IFS=' '; read -r behind ahead <<<"$ab" || true
   printf "%s %s\n" "${behind:-0}" "${ahead:-0}"; }
 
-ab_read(){ local ref="$1" ab; ab="$(git_ahead_behind "$ref" 2>/dev/null || echo "0 0")"; set -- $ab; echo "${1:-0} ${2:-0}"; }
+ab_read(){
+  local ref="$1" ab
+  ab="$(git_ahead_behind "$ref" 2>/dev/null || echo "0 0")"
+  set -- $ab
+  echo "${1:-0} ${2:-0}"
+}
 
 detect_web_dir(){ for d in apps/web web; do [[ -d "$d" ]] && { echo "$d"; return; }; done; echo ""; }
 detect_api_dir(){ for d in apps/api api crates; do [[ -f "$d/Cargo.toml" ]] && { echo "$d"; return; }; done; echo ""; }
 
 run_with_files_xargs0(){ local title="$1"; shift; if [[ -t 1 ]]; then info "$title"; fi
-  if has xargs; then xargs -0 "$@" || return $?; else local buf=() f; while IFS= read -r -d '' f; do buf+=("$f"); done; [[ $# -gt 0 ]] && "$@" "${buf[@]}"; fi; }
+  if has xargs; then
+    xargs -0 "$@" || return $?
+  else
+    local buf=() f
+    while IFS= read -r -d '' f; do
+      buf+=("$f")
+    done
+    [[ $# -gt 0 ]] && "$@" "${buf[@]}"
+  fi
+}
 # ─────────────────────────────────────────────────────────────────────────────
 # STATUS (kompakt)
 # ─────────────────────────────────────────────────────────────────────────────
@@ -294,7 +363,10 @@ guard_run(){
   local staged; staged="$(changed_files_cached || true)"
   if [[ -n "$staged" ]]; then
     local secrets
-    secrets="$(printf "%s\n" "$staged" | grep -Ei '\.env(\.|$)|(^|/)(id_rsa|id_ed25519)(\.|$)|\.pem$|\.p12$|\.keystore$' || true)"
+    secrets="$(
+      printf "%s\n" "$staged" |
+        grep -Ei '\.env(\.|$)|(^|/)(id_rsa|id_ed25519)(\.|$)|\.pem$|\.p12$|\.keystore$' || true
+    )"
     if [[ -n "$secrets" ]]; then
       echo "[BLOCKER] mögliche Secrets im Commit (Dateinamen-Match):"
       printf "%s\n" "$secrets" | sed 's/^/  - /'
@@ -309,9 +381,21 @@ guard_run(){
 
     if (( DEEP_SCAN )); then
       local leaked
-      leaked="$(git diff --cached -U0 \
-        | grep -Ei 'BEGIN (RSA|EC|OPENSSH) PRIVATE KEY|AKIA[A-Z0-9]{16}|ghp_[A-Za-z0-9]{36}|glpat-[A-Za-z0-9_-]{20,}|AWS_ACCESS_KEY_ID|SECRET(_KEY)?|TOKEN|AUTHORIZATION:|PASSWORD' \
-        || true)"
+      local secret_pattern
+      secret_pattern='BEGIN (RSA|EC|OPENSSH) PRIVATE KEY'
+      secret_pattern+='|AKIA[A-Z0-9]{16}'
+      secret_pattern+='|ghp_[A-Za-z0-9]{36}'
+      secret_pattern+='|glpat-[A-Za-z0-9_-]{20,}'
+      secret_pattern+='|AWS_ACCESS_KEY_ID'
+      secret_pattern+='|SECRET(_KEY)?'
+      secret_pattern+='|TOKEN'
+      secret_pattern+='|AUTHORIZATION:'
+      secret_pattern+='|PASSWORD'
+      leaked="$(
+        git diff --cached -U0 |
+          grep -Ei "$secret_pattern" \
+          || true
+      )"
       if [[ -n "$leaked" ]]; then
         echo "[BLOCKER] möglicher Secret-Inhalt im Diff:"
         echo "$leaked" | sed 's/^/  > /'
@@ -432,7 +516,8 @@ lint_cmd(){
     esac
 
     if (( OFFLINE )); then
-      [[ "$pm" == "npm" || "$pm" == "" ]] && warn "Offline: npx evtl. nicht verfügbar → Prettier/ESLint ggf. übersprungen."
+      [[ "$pm" == "npm" || "$pm" == "" ]] \
+        && warn "Offline: npx evtl. nicht verfügbar → Prettier/ESLint ggf. übersprungen."
     fi
 
     local has_gnu_find=0
@@ -447,18 +532,47 @@ lint_cmd(){
           -- ':(exclude)node_modules/**' ':(exclude)dist/**' ':(exclude)build/**' \
              '*.js' '*.ts' '*.tsx' '*.jsx' '*.json' '*.css' '*.scss' '*.md' '*.svelte' 2>/dev/null \
         | run_with_files_xargs0 "Prettier Check" \
-            sh -c 'cd "$1"; shift; '"$prettier_cmd"' -c -- "$@"' _ "$wd" \
+            sh -c '
+              cd "$1"
+              shift
+              '"$prettier_cmd"' -c -- "$@"
+            ' _ "$wd" \
         || run_with_files_xargs0 "Prettier Check (fallback npx)" \
-            sh -c 'cd "$1"; shift; npx --yes prettier -c -- "$@"' _ "$wd" \
+            sh -c '
+              cd "$1"
+              shift
+              npx --yes prettier -c -- "$@"
+            ' _ "$wd" \
         || rc_total=$RC_WARN
       else
         find "$wd" \( -path "$wd/node_modules" -o -path "$wd/dist" -o -path "$wd/build" \) -prune -o \
-             -type f \( -name '*.js' -o -name '*.ts' -o -name '*.tsx' -o -name '*.jsx' -o -name '*.json' -o -name '*.css' -o -name '*.scss' -o -name '*.md' -o -name '*.svelte' \) -print0 \
-        | while IFS= read -r -d '' f; do rel="${f#$wd/}"; printf '%s\0' "$rel"; done \
+             -type f \
+             \( -name '*.js' -o \
+                -name '*.ts' -o \
+                -name '*.tsx' -o \
+                -name '*.jsx' -o \
+                -name '*.json' -o \
+                -name '*.css' -o \
+                -name '*.scss' -o \
+                -name '*.md' -o \
+                -name '*.svelte' \) \
+             -print0 \
+        | while IFS= read -r -d '' f; do
+            rel="${f#$wd/}"
+            printf '%s\0' "$rel"
+          done \
         | run_with_files_xargs0 "Prettier Check" \
-            sh -c 'cd "$1"; shift; '"$prettier_cmd"' -c -- "$@"' _ "$wd" \
+            sh -c '
+              cd "$1"
+              shift
+              '"$prettier_cmd"' -c -- "$@"
+            ' _ "$wd" \
         || { (( OFFLINE )) || run_with_files_xargs0 "Prettier Check (fallback npx)" \
-               sh -c 'cd "$1"; shift; npx --yes prettier -c -- "$@"' _ "$wd"; } \
+               sh -c '
+                 cd "$1"
+                 shift
+                 npx --yes prettier -c -- "$@"
+               ' _ "$wd"; } \
         || rc_total=$RC_WARN
       fi
     fi
@@ -468,7 +582,11 @@ lint_cmd(){
     [[ -f "$wd/.eslintrc" || -f "$wd/.eslintrc.js" || -f "$wd/.eslintrc.cjs" || -f "$wd/.eslintrc.json" \
        || -f "$wd/eslint.config.js" || -f "$wd/eslint.config.mjs" || -f "$wd/eslint.config.cjs" ]] && has_eslint_cfg=1
     if (( has_eslint_cfg )); then
-      run_soft "ESLint" bash -c "cd '$wd' && $eslint_cmd -v >/dev/null 2>&1 && $eslint_cmd . --ext .js,.cjs,.mjs,.ts,.tsx,.svelte" \
+      run_soft "ESLint" bash -c '
+        cd '"$wd"'
+        $eslint_cmd -v >/dev/null 2>&1
+        $eslint_cmd . --ext .js,.cjs,.mjs,.ts,.tsx,.svelte
+      ' \
       || { if (( OFFLINE )); then warn "ESLint übersprungen (offline)"; false; \
            else run_soft "ESLint (fallback npx)" \
                   bash -c "cd '$wd' && npx --yes eslint . --ext .js,.cjs,.mjs,.ts,.tsx,.svelte"; fi; } \
@@ -481,7 +599,10 @@ lint_cmd(){
   if [[ -n "$ad" && -f "$ad/Cargo.toml" ]] && has cargo; then
     run_soft "cargo fmt --check" bash -lc "cd '$ad' && cargo fmt --all -- --check" || rc_total=$RC_WARN
     if rustup component list 2>/dev/null | grep -q 'clippy.*(installed)'; then
-      run_soft "cargo clippy (Hinweise)" bash -lc "cd '$ad' && cargo clippy --all-targets --all-features -q" || rc_total=$RC_WARN
+      run_soft "cargo clippy (Hinweise)" bash -lc '
+        cd '"$ad"'
+        cargo clippy --all-targets --all-features -q
+      ' || rc_total=$RC_WARN
     else
       warn "clippy nicht installiert – übersprungen."
     fi
@@ -500,7 +621,9 @@ lint_cmd(){
         | run_with_files_xargs0 "hadolint" hadolint || rc_total=$RC_WARN
     fi
   fi
-  if has actionlint && [[ -d ".github/workflows" ]]; then run_soft "actionlint" actionlint || rc_total=$RC_WARN; fi
+  if has actionlint && [[ -d ".github/workflows" ]]; then
+    run_soft "actionlint" actionlint || rc_total=$RC_WARN
+  fi
 
   (( rc_total==RC_OK )) && ok "Lint OK" || warn "Lint mit Hinweisen (rc=$rc_total)."
   printf "%s\n" "$rc_total"; return 0
@@ -519,7 +642,10 @@ pm_test(){
 test_cmd(){
   require_repo
   local rc_web=0 rc_api=0 wd ad pid_web= pid_api=
-  trap '[[ -n "${pid_web-}" ]] && kill "$pid_web" 2>/dev/null || true; [[ -n "${pid_api-}" ]] && kill "$pid_api" 2>/dev/null || true' INT
+  trap '
+    [[ -n "${pid_web-}" ]] && kill "$pid_web" 2>/dev/null || true
+    [[ -n "${pid_api-}" ]] && kill "$pid_api" 2>/dev/null || true
+  ' INT
   wd="$(detect_web_dir || true)"; ad="$(detect_api_dir || true)"
   if [[ -n "$wd" && -f "$wd/package.json" ]]; then
     info "Web-Tests…"; ( pm_test "$wd" ) & pid_web=$!
@@ -850,14 +976,30 @@ version_cmd(){
       local pj="package.json"
       [[ -f "$pj" ]] || die "package.json fehlt."
       local nv="$1"; [[ -z "$nv" ]] && die "Neue Version fehlt."
-      if has jq; then jq ".version=\"$nv\"" "$pj" > "$pj.tmp" && mv "$pj.tmp" "$pj"
-      else awk -v ver="$nv" 'BEGIN{done=0} !done && /"version"[[:space:]]*:/ {sub(/"version"[[:space:]]*:[[:space:]]*"[^"]*"/, "\"version\": \"" ver "\""); done=1} {print}' "$pj" > "$pj.tmp" && mv "$pj.tmp" "$pj"; fi
+      if has jq; then
+        jq ".version=\"$nv\"" "$pj" > "$pj.tmp"
+        mv "$pj.tmp" "$pj"
+      else
+        awk -v ver="$nv" '
+          BEGIN { done=0 }
+          !done && /"version"[[:space:]]*:/ {
+            sub(/"version"[[:space:]]*:[[:space:]]*"[^"]*"/, "\"version\": \"" ver "\"")
+            done=1
+          }
+          { print }
+        ' "$pj" > "$pj.tmp"
+        mv "$pj.tmp" "$pj"
+      fi
       (( do_commit )) && { git add -A && git commit -m "chore(version): bump to v$nv"; }
       ok "Version auf $nv gesetzt."
       ;;
     show|"")
-      if [[ -f package.json ]]; then jq -r .version package.json 2>/dev/null || awk -F'"' '/version/{print $4; exit}' package.json
-      else echo "keine package.json"; fi ;;
+      if [[ -f package.json ]]; then
+        jq -r .version package.json 2>/dev/null \
+          || awk -F'"' '/version/{print $4; exit}' package.json
+      else
+        echo "keine package.json"
+      fi ;;
     *) die "Unbekannter version-Befehl: $sub";;
   esac
 }


### PR DESCRIPTION
## Summary
- reflowed the archived monolith script to keep shell helpers under the 120-character markdownlint limit
- added the missing blank lines around the README fenced block and heading so markdownlint passes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9ff891950832cbe2c42cdebbba5fc