### PR TITLE
Fix shell script shebang spacing

### DIFF
--- a/cmd/guard.bash
+++ b/cmd/guard.bash
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 cmd_guard() {
   guard_run "$@"
 }

--- a/cmd/status.bash
+++ b/cmd/status.bash
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 cmd_status() {
   status_cmd "$@"
 }

--- a/modules/doctor.bash
+++ b/modules/doctor.bash
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # Doctor module: basic repository health checks
 
 doctor_cmd() {

--- a/modules/guard.bash
+++ b/modules/guard.bash
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # Guard-Modul: Lint- und Testläufe (aus Monolith portiert)
 
 guard_run() {

--- a/modules/json.bash
+++ b/modules/json.bash
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # shellcheck shell=bash
 
 json_escape() {

--- a/modules/profile.bash
+++ b/modules/profile.bash
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # shellcheck shell=bash
 
 PROFILE_FILE=""

--- a/modules/semver.bash
+++ b/modules/semver.bash
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # shellcheck shell=bash
 
 # Minimal SemVer helper utilities.

--- a/modules/status.bash
+++ b/modules/status.bash
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # Status-Modul: Projektstatus anzeigen
 
 status_cmd() {


### PR DESCRIPTION
## Summary
- add the missing blank line after the shebang in guard/status commands and shared modules to match shfmt formatting

## Testing
- python - <<'PY'
import pathlib
missing=[]
for path in pathlib.Path('.').rglob('*.bash'):
    text=path.read_text().splitlines()
    if not text:
        continue
    if text[0].startswith('#!'):
        if len(text)==1 or text[1].strip():
            missing.append(str(path))
for path in pathlib.Path('.').rglob('*.sh'):
    text=path.read_text().splitlines()
    if not text:
        continue
    if text[0].startswith('#!'):
        if len(text)==1 or text[1].strip():
            missing.append(str(path))
print(missing)
PY

------
https://chatgpt.com/codex/tasks/task_e_68da0046fc30832c982c334a9eeff257