### PR TITLE
Fix markdownlint warnings in README and archived doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ wgx --list 2>/dev/null || wgx commands 2>/dev/null || ls -1 cmd/
   bats -r tests
   ```
 
+
 ## Commands
 
 ### reload
@@ -80,6 +81,7 @@ Anschließend kannst du sie dort projektspezifisch anpassen.
 
 Automatisierte Tests werden über `tests/` organisiert (z. B. mit [Bats](https://bats-core.readthedocs.io/)).
 Ergänzende Checks kannst du via `wgx selftest` starten.
+
 
 ## Architecture Note — Modular Only
 

--- a/docs/archive/wgx_monolith_20250925T130147Z.md
+++ b/docs/archive/wgx_monolith_20250925T130147Z.md
@@ -76,7 +76,10 @@ is_codespace(){ [[ -n "${CODESPACE_NAME-}" ]]; }
 # REPO CONTEXT
 # ─────────────────────────────────────────────────────────────────────────────
 is_git_repo(){ git rev-parse --is-inside-work-tree >/dev/null 2>&1; }
-require_repo(){ has git || die "git nicht installiert."; is_git_repo || die "Nicht im Git-Repo."; }
+require_repo(){
+  has git || die "git nicht installiert."
+  is_git_repo || die "Nicht im Git-Repo."
+}
 
 _root_resolve(){
   local here="$1"
@@ -516,8 +519,9 @@ lint_cmd(){
     esac
 
     if (( OFFLINE )); then
-      [[ "$pm" == "npm" || "$pm" == "" ]] \
-        && warn "Offline: npx evtl. nicht verfügbar → Prettier/ESLint ggf. übersprungen."
+        [[ "$pm" == "npm" || "$pm" == "" ]] \
+          && warn \
+            "Offline: npx evtl. nicht verfügbar → Prettier/ESLint ggf. übersprungen."
     fi
 
     local has_gnu_find=0
@@ -839,8 +843,11 @@ send_cmd(){
     signflag="$(maybe_sign_flag || true)"
     local args=(); ((no_verify)) && args+=("--no-verify")
     if [[ -z "$msg" ]]; then msg="$title"; fi
-    if [[ -n "$signflag" ]]; then git commit -m "$msg" "$signflag" "${args[@]}" || die "Commit fehlgeschlagen."
-    else git commit -m "$msg" "${args[@]}" || die "Commit fehlgeschlagen."; fi
+    if [[ -n "$signflag" ]]; then
+      git commit -m "$msg" "$signflag" "${args[@]}" || die "Commit fehlgeschlagen."
+    else
+      git commit -m "$msg" "${args[@]}" || die "Commit fehlgeschlagen."
+    fi
   fi
 
   # Push


### PR DESCRIPTION
## Summary
- add required spacing before Markdown fences and headings in the README
- wrap long lines in the archived monolith documentation for lint compliance

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da02571a0c832c8a9379c614c25d7f