### PR TITLE
Fix README markdownlint spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ wgx --list 2>/dev/null || wgx commands 2>/dev/null || ls -1 cmd/
   bats -r tests
   ```
 
-
 ## Commands
 
 ### reload
@@ -81,7 +80,6 @@ Anschließend kannst du sie dort projektspezifisch anpassen.
 
 Automatisierte Tests werden über `tests/` organisiert (z. B. mit [Bats](https://bats-core.readthedocs.io/)).
 Ergänzende Checks kannst du via `wgx selftest` starten.
-
 
 ## Architecture Note — Modular Only
 


### PR DESCRIPTION
## Summary
- remove duplicate blank lines around Commands and Architecture sections to satisfy markdownlint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da0552abf4832cbe4cab2b9af31607