### PR TITLE
Format bash arithmetic expressions for shfmt compliance

### DIFF
--- a/cmd/selftest.bash
+++ b/cmd/selftest.bash
@@ -22,7 +22,7 @@ selftest_check_bins() {
     if command -v "$bin" >/dev/null 2>&1; then
       selftest_ok "$label: $bin found"
     else
-      if ((critical)); then
+      if (( critical )); then
         selftest_warn "$label: $bin missing"
         miss=1
       else
@@ -66,7 +66,7 @@ cmd_selftest() {
     selftest_info "Hinweis: Selbsttest außerhalb eines Git-Repos – einige Kommandos erfordern eins."
   fi
 
-  if ((had_warn == 0)); then
+  if (( had_warn == 0 )); then
     selftest_ok "Selftest abgeschlossen."
     return 0
   fi

--- a/cmd/task.bash
+++ b/cmd/task.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 cmd_task() {
-  if (($# == 0)); then
+  if (( $# == 0 )); then
     die "Usage: wgx task <name> [--] [args...]"
   fi
 

--- a/cmd/tasks.bash
+++ b/cmd/tasks.bash
@@ -2,7 +2,7 @@
 
 cmd_tasks() {
   local json=0 safe_only=0 include_groups=0
-  while (($#)); do
+  while (( $# )); do
     case "$1" in
     --json) json=1 ;;
     --safe) safe_only=1 ;;
@@ -29,26 +29,26 @@ USAGE
     return 1
   fi
 
-  if ((json)); then
+  if (( json )); then
     profile::tasks_json "$safe_only" "$include_groups"
     return $?
   fi
 
   local -a _task_names=()
   mapfile -t _task_names < <(profile::_task_keys)
-  if ((${#_task_names[@]} == 0)); then
+  if (( ${#_task_names[@]} == 0 )); then
     warn "No tasks defined in manifest."
     return 0
   fi
 
-  if ((include_groups)); then
+  if (( include_groups )); then
     declare -A _groups=()
     declare -A _order_seen=()
     local -a _order=()
     local name group safe
     for name in "${_task_names[@]}"; do
       safe="$(profile::_task_safe "$name")"
-      if ((safe_only)) && [[ "$safe" != "1" ]]; then
+      if (( safe_only )) && [[ "$safe" != "1" ]]; then
         continue
       fi
       group="$(profile::_task_group "$name")"
@@ -59,7 +59,7 @@ USAGE
         _order+=("$group")
       fi
     done
-    if ((${#_order[@]} == 0)); then
+    if (( ${#_order[@]} == 0 )); then
       warn "No tasks matched filters."
       return 0
     fi
@@ -77,12 +77,12 @@ USAGE
   local task safe
   for task in "${_task_names[@]}"; do
     safe="$(profile::_task_safe "$task")"
-    if ((safe_only)) && [[ "$safe" != "1" ]]; then
+    if (( safe_only )) && [[ "$safe" != "1" ]]; then
       continue
     fi
     filtered+=("$task")
   done
-  if ((${#filtered[@]} == 0)); then
+  if (( ${#filtered[@]} == 0 )); then
     warn "No tasks matched filters."
     return 0
   fi

--- a/modules/profile.bash
+++ b/modules/profile.bash
@@ -238,10 +238,10 @@ if isinstance(tasks, dict):
 
 PY
   local status=$?
-  if ((status == 0)); then
+  if (( status == 0 )); then
     return 0
   fi
-  if ((status == 3)); then
+  if (( status == 3 )); then
     return 3
   fi
   return 1
@@ -369,12 +369,12 @@ profile::load() {
       status=0
     else
       local rc=$?
-      if ((rc == 3)); then
+      if (( rc == 3 )); then
         status=3
       fi
     fi
   fi
-  if ((status != 0)); then
+  if (( status != 0 )); then
     profile::_flat_yaml_parse "$file"
   fi
   profile::_collect_env_keys
@@ -425,7 +425,7 @@ profile::ensure_version() {
 }
 
 profile::_task_keys() {
-  if ((${#WGX_TASK_CMDS[@]} == 0)); then
+  if (( ${#WGX_TASK_CMDS[@]} == 0 )); then
     return 0
   fi
   local key
@@ -471,7 +471,7 @@ profile::tasks_json() {
   for name in $(profile::_task_keys); do
     key="$name"
     safe="$(profile::_task_safe "$key")"
-    if ((safe_only)) && [[ "$safe" != "1" ]]; then
+    if (( safe_only )) && [[ "$safe" != "1" ]]; then
       continue
     fi
     desc="$(profile::_task_desc "$key")"
@@ -482,7 +482,7 @@ profile::tasks_json() {
     sep=','
   done
   printf ']'
-  if ((include_groups)); then
+  if (( include_groups )); then
     local -A groups=()
     for name in $(profile::_task_keys); do
       group="$(profile::_task_group "$name")"
@@ -530,7 +530,7 @@ profile::run_task() {
   mapfile -t envs < <(profile::env_apply)
   local dryrun="${DRYRUN:-0}"
   local args=()
-  while (($#)); do
+  while (( $# )); do
     args+=("$1")
     shift || true
   done
@@ -541,7 +541,7 @@ profile::run_task() {
     if [[ -n $payload ]]; then
       read -r -a cmd <<<"$payload"
     fi
-    if ((dryrun)); then
+    if (( dryrun )); then
       printf 'DRY: '
       local item
       for item in "${envs[@]}"; do
@@ -557,13 +557,13 @@ profile::run_task() {
       return 0
     fi
     (
-      ((${#envs[@]})) && export "${envs[@]}"
+      (( ${#envs[@]} )) && export "${envs[@]}"
       exec "${cmd[@]}" "${args[@]}"
     )
     ;;
   STR:*)
     local command="${spec#STR:}"
-    if ((dryrun)); then
+    if (( dryrun )); then
       printf 'DRY: '
       local item
       for item in "${envs[@]}"; do
@@ -577,8 +577,8 @@ profile::run_task() {
       return 0
     fi
     (
-      ((${#envs[@]})) && export "${envs[@]}"
-      if ((${#args[@]})); then
+      (( ${#envs[@]} )) && export "${envs[@]}"
+      if (( ${#args[@]} )); then
         local extra=""
         local arg
         for arg in "${args[@]}"; do
@@ -614,7 +614,7 @@ profile::validate_manifest() {
       ;;
     esac
   fi
-  if ((${#WGX_TASK_CMDS[@]} == 0)); then
+  if (( ${#WGX_TASK_CMDS[@]} == 0 )); then
     _errors_ref+=("no_tasks")
   fi
   local key spec
@@ -636,7 +636,7 @@ profile::validate_manifest() {
       missing+=("$cap")
     fi
   done
-  if ((${#missing[@]})); then
+  if (( ${#missing[@]} )); then
     _missing_caps_ref=("${missing[@]}")
     _errors_ref+=("missing_capabilities")
   fi

--- a/modules/semver.bash
+++ b/modules/semver.bash
@@ -18,9 +18,9 @@ semver_cmp() {
   local l1 l2 l3 r1 r2 r3
   IFS='.' read -r l1 l2 l3 <<<"$left"
   IFS='.' read -r r1 r2 r3 <<<"$right"
-  if ((l1 > r1)) || ((l1 == r1 && l2 > r2)) || ((l1 == r1 && l2 == r2 && l3 > r3)); then
+  if (( l1 > r1 )) || (( l1 == r1 && l2 > r2 )) || (( l1 == r1 && l2 == r2 && l3 > r3 )); then
     return 1
-  elif ((l1 < r1)) || ((l1 == r1 && l2 < r2)) || ((l1 == r1 && l2 == r2 && l3 < r3)); then
+  elif (( l1 < r1 )) || (( l1 == r1 && l2 < r2 )) || (( l1 == r1 && l2 == r2 && l3 < r3 )); then
     return 2
   fi
   return 0
@@ -53,7 +53,7 @@ semver_in_caret_range() {
   range="$(semver_norm "$range")"
   local major
   IFS='.' read -r major _ _ <<<"$range"
-  local next_major=$((major + 1))
+  local next_major=$(( major + 1 ))
   local lower="$range"
   local upper="${next_major}.0.0"
   semver_ge "$have" "$lower" && semver_lt "$have" "$upper"

--- a/modules/status.bash
+++ b/modules/status.bash
@@ -49,7 +49,7 @@ status_cmd() {
       fi
     done
   fi
-  if ((!info_present)); then
+  if (( ! info_present )); then
     local fallback_present=0
     if [[ -d web ]]; then
       echo "▶ Web-Verzeichnis: web"
@@ -64,7 +64,7 @@ status_cmd() {
       fallback_present=1
     fi
 
-    ((fallback_present)) && info_present=1
+    (( fallback_present )) && info_present=1
   fi
 
   # OFFLINE?


### PR DESCRIPTION
## Summary
- add spacing inside arithmetic conditionals across task- and profile-related bash scripts
- keep dry-run helpers and environment export logic shfmt-compliant
- normalize semver helper arithmetic expansion for formatting checks

## Testing
- not run (shfmt unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68da076ac258832cbf65665c713fbc79