### PR TITLE
Ensure JSON error list comma flag is integer

### DIFF
--- a/cmd/validate.bash
+++ b/cmd/validate.bash
@@ -56,7 +56,7 @@ validate::run() {
       printf '"ok":false'
     fi
     printf ',"errors":['
-    local first=1
+    local -i first=1
     local e
     for e in "${errs[@]}"; do
       if (( first )); then


### PR DESCRIPTION
## Summary
- declare the JSON error list comma tracking flag as an integer so arithmetic checks succeed

## Testing
- bash -n cmd/validate.bash

------
https://chatgpt.com/codex/tasks/task_e_68da0b565848832c8c6a429e7377243b