### PR TITLE
Add bash shebang to validate script

### DIFF
--- a/cmd/validate.bash
+++ b/cmd/validate.bash
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # shellcheck shell=bash
 
 if ! declare -F require_repo >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- add an explicit bash shebang to `cmd/validate.bash` so it runs under bash when invoked directly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da0c3534ac832c9281d7c3806a89e9