### PR TITLE
Fix fallback presence check in status module

### DIFF
--- a/modules/status.bash
+++ b/modules/status.bash
@@ -64,7 +64,9 @@ status_cmd() {
       fallback_present=1
     fi
 
-    (( fallback_present )) && info_present=1
+    if [[ $fallback_present -ne 0 ]]; then
+      info_present=1
+    fi
   fi
 
   # OFFLINE?


### PR DESCRIPTION
## Summary
- ensure fallback status detection only activates when fallback directories were found

## Testing
- bash -n modules/status.bash

------
https://chatgpt.com/codex/tasks/task_e_68da0d292364832cb1281eb2ed9dba18