### PR TITLE
Fix caret range check under bash strict mode

### DIFF
--- a/modules/semver.bash
+++ b/modules/semver.bash
@@ -53,8 +53,11 @@ semver_in_caret_range() {
   range="$(semver_norm "$range")"
   local major
   IFS='.' read -r major _ _ <<<"$range"
-  local next_major=$(( major + 1 ))
+  local next_major=$((major + 1))
   local lower="$range"
   local upper="${next_major}.0.0"
-  semver_ge "$have" "$lower" && semver_lt "$have" "$upper"
+  if semver_ge "$have" "$lower" && semver_lt "$have" "$upper"; then
+    return 0
+  fi
+  return 1
 }


### PR DESCRIPTION
## Summary
- guard the caret range comparison with an if-statement so it returns cleanly
- adjust arithmetic expansion formatting to satisfy shfmt

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da0f47fc30832cbee8d7c2fdfafc1f