### PR TITLE
Grant pull request write permission to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
+  pull-requests: write
   contents: read
 
 concurrency:


### PR DESCRIPTION
## Summary
- grant the CI workflow pull-request write permissions so it can access PR data while retaining read access to contents

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68da1c2e6380832ca7e25496221c5f16