### PR TITLE
docs: add bilingual CLI contract references

### DIFF
--- a/docs/ADR-0001__central-cli-contract.de.md
+++ b/docs/ADR-0001__central-cli-contract.de.md
@@ -1,0 +1,22 @@
+# ADR-0001: Zentrales CLI-Contract
+
+> Englische Version: [ADR-0001__central-cli-contract.en.md](ADR-0001__central-cli-contract.en.md)
+
+## Status
+Akzeptiert
+
+## Kontext
+Die wgx-Toolchain unterstützt mehrere Projekte und Arbeitsplätze. Bisher existierten unterschiedliche Varianten des CLI-Vertrags (Command Line Interface Contract) in einzelnen Repositories, was zu inkonsistentem Verhalten und wiederholtem Abstimmungsaufwand führte. Neue Funktionen mussten mehrfach dokumentiert und abgestimmt werden, und automatisierte Tests konnten nicht zuverlässig wiederverwendet werden. Darüber hinaus nutzen Mitarbeiter verschiedene Entwicklungsumgebungen (Termux, VS Code Remote, klassische Linux-Setups), wodurch Abweichungen in der CLI-Konfiguration schnell zu Fehlern führen.
+
+## Entscheidung
+Wir etablieren einen zentral gepflegten CLI-Contract innerhalb von wgx. Der Contract wird in `docs` versioniert, beschreibt erwartete Befehle, Konfigurationsdateien (z. B. `profile.yml`) und deren Schnittstellen, und dient als Referenz für alle abhängigen Projekte. Änderungen am Contract erfolgen über Pull Requests inklusive ADR-Aktualisierung, wodurch Transparenz und Nachvollziehbarkeit gewährleistet werden.
+
+## Konsequenzen
+- Einheitliches Verhalten: Alle Projekte orientieren sich am selben Contract und können kompatible Tooling-Skripte bereitstellen.
+- Geringerer Abstimmungsaufwand: Dokumentation, Tests und Runbooks müssen nur einmal gepflegt werden.
+- Schnellere Onboarding-Prozesse: Neue Teammitglieder erhalten eine zentrale Referenz.
+- Höhere Wartbarkeit: Inkompatible Änderungen werden frühzeitig erkannt, weil sie über den zentralen Contract abgestimmt werden müssen.
+
+## Offene Fragen
+- Wie werden ältere Projekte migriert, die noch eigene CLI-Definitionen haben?
+- Welche automatisierten Validierungen sollen beim Ändern des Contracts verpflichtend sein?

--- a/docs/ADR-0001__central-cli-contract.en.md
+++ b/docs/ADR-0001__central-cli-contract.en.md
@@ -1,0 +1,22 @@
+# ADR-0001: Central CLI Contract
+
+> German version: [ADR-0001__central-cli-contract.de.md](ADR-0001__central-cli-contract.de.md)
+
+## Status
+Accepted
+
+## Context
+The wgx toolchain supports multiple projects and workstations. Until now, different variants of the CLI contract lived in individual repositories, leading to inconsistent behaviour and repeated coordination effort. New features had to be documented and agreed upon multiple times, and automated tests could not be reused reliably. On top of that, engineers work from different environments (Termux, VS Code Remote, traditional Linux setups), which makes configuration drift in the CLI a common source of errors.
+
+## Decision
+We maintain a centrally governed CLI contract within wgx. The contract is versioned in `docs`, describes expected commands, configuration files (for example `profile.yml`), and their interfaces, and serves as the reference for all dependent projects. Contract changes must go through pull requests, including an ADR update, so that transparency and traceability are ensured.
+
+## Consequences
+- Consistent behaviour: all projects align to the same contract and can ship compatible tooling scripts.
+- Less coordination overhead: documentation, tests, and runbooks only need to be maintained once.
+- Faster onboarding: new team members get a single reference point.
+- Higher maintainability: incompatible changes are detected early because they must be negotiated via the central contract.
+
+## Open Questions
+- How do we migrate legacy projects that still maintain their own CLI definitions?
+- Which automated validations must run when the contract changes?

--- a/docs/Glossar.de.md
+++ b/docs/Glossar.de.md
@@ -1,0 +1,12 @@
+# Glossar
+
+> Englische Version: [Glossary.en.md](Glossary.en.md)
+
+## wgx
+Interne Toolchain und Sammel-Repository, das Build-Skripte, Templates und Dokumentation für verbundene Projekte bereitstellt.
+
+## `profile.yml`
+Zentrale Konfigurationsdatei, mit der lokale Profile (z. B. für Dev, CI oder spezielle Kunden) gesteuert werden. Sie definiert CLI-Parameter, Umgebungsvariablen und Pfade und dient als Bindeglied zwischen zentralem Contract und projektspezifischen Einstellungen.
+
+## Contract (CLI-Contract)
+Vereinbarung über Befehle, Optionen, Dateistrukturen und Seiteneffekte des wgx-CLI. Er legt fest, welche Schnittstellen stabil bleiben müssen, damit abhängige Projekte konsistent arbeiten können.

--- a/docs/Glossary.en.md
+++ b/docs/Glossary.en.md
@@ -1,0 +1,12 @@
+# Glossary
+
+> German version: [Glossar.de.md](Glossar.de.md)
+
+## wgx
+Internal toolchain and umbrella repository that provides build scripts, templates, and documentation for related projects.
+
+## `profile.yml`
+Central configuration file that controls local profiles (for example dev, CI, or customer-specific). It defines CLI parameters, environment variables, and paths and links the central contract with project-specific settings.
+
+## Contract (CLI Contract)
+Agreement that describes commands, options, file structures, and side effects of the wgx CLI. It defines which interfaces must remain stable so that dependent projects can work consistently.

--- a/docs/Runbook.de.md
+++ b/docs/Runbook.de.md
@@ -1,0 +1,43 @@
+# Runbook: wgx CLI
+
+> Englische Version: [Runbook.en.md](Runbook.en.md)
+
+## Quick-Links
+- Contract-Kompatibilität prüfen: `wgx validate`
+- Linting ausführen (auch für Git-Hooks): `wgx lint`
+- Umgebung diagnostizieren: `wgx doctor`
+
+## Häufige Fehler und Lösungen
+
+### `profile.yml` wird nicht gefunden
+- Prüfen, ob das Arbeitsverzeichnis korrekt gesetzt ist (z. B. Projektwurzel).
+- Mit `wgx profile list` sicherstellen, dass das Profil geladen werden kann.
+- Falls mehrere Profile vorhanden sind, den Pfad per `WGX_PROFILE_PATH` explizit setzen.
+
+### `wgx`-Befehl schlägt mit Python-Fehlern fehl
+- Python-Umgebung aktivieren (`.venv/bin/activate` oder `pipx run`).
+- Fehlende Abhängigkeiten mit `pip install -r requirements.txt` nachinstallieren.
+- Bei globaler Installation prüfen, ob Version mit zentralem Contract kompatibel ist.
+
+### Git-Hooks blockieren Commits
+- `wgx lint` manuell ausführen, um Fehler zu sehen.
+- Falls Hook veraltet ist, Repository aktualisieren und `wgx setup` erneut laufen lassen.
+
+## Tipps für Termux
+- Termux-Repo aktualisieren (`pkg update`), bevor Python/Node installiert wird.
+- Essentials installieren: `pkg install jq git python`.
+- `pipx` ergänzen (`pip install pipx && pipx ensurepath`), um `wgx` isoliert zu nutzen.
+- Speicherzugriff auf das Projektverzeichnis gewähren (`termux-setup-storage`).
+
+## Tipps für VS Code (Remote / Dev Containers)
+- Die `profile.yml` als Workspace-File markieren, damit Änderungen synchronisiert werden.
+- Aufgaben (`wgx`-Tasks) als VS Code Tasks integrieren, um Befehle mit einem Klick zu starten.
+- Bei Dev Containers sicherstellen, dass das Volume die `~/.wgx`-Konfiguration persistiert, z. B.:
+
+```json
+{
+  "mounts": [
+    "source=${localEnv:HOME}/.wgx,target=/home/vscode/.wgx,type=bind,consistency=cached"
+  ]
+}
+```

--- a/docs/Runbook.en.md
+++ b/docs/Runbook.en.md
@@ -1,0 +1,43 @@
+# Runbook: wgx CLI
+
+> German version: [Runbook.de.md](Runbook.de.md)
+
+## Quick Links
+- Validate contract compatibility: `wgx validate`
+- Run linting (also used by Git hooks): `wgx lint`
+- Diagnose environment issues: `wgx doctor`
+
+## Common Issues and Fixes
+
+### `profile.yml` cannot be found
+- Confirm that you are in the correct working directory (usually the project root).
+- Use `wgx profile list` to ensure that the profile can be discovered.
+- If multiple profiles exist, set `WGX_PROFILE_PATH` explicitly.
+
+### `wgx` fails with Python errors
+- Activate the Python environment (`.venv/bin/activate` or `pipx run`).
+- Install missing dependencies with `pip install -r requirements.txt`.
+- For global installations, confirm that the version matches the central contract.
+
+### Git hooks block commits
+- Run `wgx lint` manually to inspect the reported issues.
+- If the hook is outdated, update the repository and run `wgx setup` again.
+
+## Termux Tips
+- Update the package repository first with `pkg update`.
+- Install the essentials: `pkg install jq git python`.
+- Add `pipx` for isolated CLI usage (`pip install pipx && pipx ensurepath`).
+- Grant storage access to the project directory via `termux-setup-storage`.
+
+## VS Code (Remote / Dev Containers) Tips
+- Mark `profile.yml` as a workspace file so changes are synced.
+- Add `wgx` tasks as VS Code tasks for one-click execution.
+- Persist the `~/.wgx` configuration when using Dev Containers, for example:
+
+```json
+{
+  "mounts": [
+    "source=${localEnv:HOME}/.wgx,target=/home/vscode/.wgx,type=bind,consistency=cached"
+  ]
+}
+```


### PR DESCRIPTION
## Summary
- provide English counterparts for the CLI contract ADR, glossary, and runbook alongside the German originals
- add cross-links between language versions and expand the runbook with quick links plus extra Termux and Dev Container guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da3b946324832c85231587326ae8c7