### PR TITLE
Fix markdownlint issues in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Anschließend kannst du sie dort projektspezifisch anpassen.
   - `v1.1`: reichere Spezifikation (Arrays, desc/group/safe, envDefaults/Overrides, requiredWgx-Objekt)
 
 ### Minimales Beispiel (v1)
+
 ```yaml
 wgx:
   apiVersion: v1

--- a/docs/ADR-0001__central-cli-contract.de.md
+++ b/docs/ADR-0001__central-cli-contract.de.md
@@ -3,20 +3,35 @@
 > Englische Version: [ADR-0001__central-cli-contract.en.md](ADR-0001__central-cli-contract.en.md)
 
 ## Status
+
 Akzeptiert
 
 ## Kontext
-Die wgx-Toolchain unterstützt mehrere Projekte und Arbeitsplätze. Bisher existierten unterschiedliche Varianten des CLI-Vertrags (Command Line Interface Contract) in einzelnen Repositories, was zu inkonsistentem Verhalten und wiederholtem Abstimmungsaufwand führte. Neue Funktionen mussten mehrfach dokumentiert und abgestimmt werden, und automatisierte Tests konnten nicht zuverlässig wiederverwendet werden. Darüber hinaus nutzen Mitarbeiter verschiedene Entwicklungsumgebungen (Termux, VS Code Remote, klassische Linux-Setups), wodurch Abweichungen in der CLI-Konfiguration schnell zu Fehlern führen.
+
+Die wgx-Toolchain unterstützt mehrere Projekte und Arbeitsplätze. Bisher existierten unterschiedliche Varianten des
+CLI-Vertrags (Command Line Interface Contract) in einzelnen Repositories, was zu inkonsistentem Verhalten und
+wiederholtem Abstimmungsaufwand führte. Neue Funktionen mussten mehrfach dokumentiert und abgestimmt werden, und
+automatisierte Tests konnten nicht zuverlässig wiederverwendet werden. Darüber hinaus nutzen Mitarbeiter verschiedene
+Entwicklungsumgebungen (Termux, VS Code Remote, klassische Linux-Setups), wodurch Abweichungen in der CLI-Konfiguration
+schnell zu Fehlern führen.
 
 ## Entscheidung
-Wir etablieren einen zentral gepflegten CLI-Contract innerhalb von wgx. Der Contract wird in `docs` versioniert, beschreibt erwartete Befehle, Konfigurationsdateien (z. B. `profile.yml`) und deren Schnittstellen, und dient als Referenz für alle abhängigen Projekte. Änderungen am Contract erfolgen über Pull Requests inklusive ADR-Aktualisierung, wodurch Transparenz und Nachvollziehbarkeit gewährleistet werden.
+
+Wir etablieren einen zentral gepflegten CLI-Contract innerhalb von wgx. Der Contract wird in `docs` versioniert,
+beschreibt erwartete Befehle, Konfigurationsdateien (z. B. `profile.yml`) und deren Schnittstellen, und dient als
+Referenz für alle abhängigen Projekte. Änderungen am Contract erfolgen über Pull Requests inklusive ADR-Aktualisierung,
+wodurch Transparenz und Nachvollziehbarkeit gewährleistet werden.
 
 ## Konsequenzen
-- Einheitliches Verhalten: Alle Projekte orientieren sich am selben Contract und können kompatible Tooling-Skripte bereitstellen.
+
+- Einheitliches Verhalten: Alle Projekte orientieren sich am selben Contract und können kompatible Tooling-Skripte
+  bereitstellen.
 - Geringerer Abstimmungsaufwand: Dokumentation, Tests und Runbooks müssen nur einmal gepflegt werden.
 - Schnellere Onboarding-Prozesse: Neue Teammitglieder erhalten eine zentrale Referenz.
-- Höhere Wartbarkeit: Inkompatible Änderungen werden frühzeitig erkannt, weil sie über den zentralen Contract abgestimmt werden müssen.
+- Höhere Wartbarkeit: Inkompatible Änderungen werden frühzeitig erkannt, weil sie über den zentralen Contract
+  abgestimmt werden müssen.
 
 ## Offene Fragen
+
 - Wie werden ältere Projekte migriert, die noch eigene CLI-Definitionen haben?
 - Welche automatisierten Validierungen sollen beim Ändern des Contracts verpflichtend sein?

--- a/docs/Runbook.en.md
+++ b/docs/Runbook.en.md
@@ -3,6 +3,7 @@
 > German version: [Runbook.de.md](Runbook.de.md)
 
 ## Quick Links
+
 - Validate contract compatibility: `wgx validate`
 - Run linting (also used by Git hooks): `wgx lint`
 - Diagnose environment issues: `wgx doctor`
@@ -10,26 +11,31 @@
 ## Common Issues and Fixes
 
 ### `profile.yml` cannot be found
+
 - Confirm that you are in the correct working directory (usually the project root).
 - Use `wgx profile list` to ensure that the profile can be discovered.
 - If multiple profiles exist, set `WGX_PROFILE_PATH` explicitly.
 
 ### `wgx` fails with Python errors
+
 - Activate the Python environment (`.venv/bin/activate` or `pipx run`).
 - Install missing dependencies with `pip install -r requirements.txt`.
 - For global installations, confirm that the version matches the central contract.
 
 ### Git hooks block commits
+
 - Run `wgx lint` manually to inspect the reported issues.
 - If the hook is outdated, update the repository and run `wgx setup` again.
 
 ## Termux Tips
+
 - Update the package repository first with `pkg update`.
 - Install the essentials: `pkg install jq git python`.
 - Add `pipx` for isolated CLI usage (`pip install pipx && pipx ensurepath`).
 - Grant storage access to the project directory via `termux-setup-storage`.
 
 ## VS Code (Remote / Dev Containers) Tips
+
 - Mark `profile.yml` as a workspace file so changes are synced.
 - Add `wgx` tasks as VS Code tasks for one-click execution.
 - Persist the `~/.wgx` configuration when using Dev Containers, for example:


### PR DESCRIPTION
## Summary
- wrap long paragraphs and add required blank lines in the German ADR to satisfy markdownlint
- add spacing around code blocks in the README so fences meet markdownlint rules
- ensure runbook lists are surrounded by blank lines for markdownlint compliance

## Testing
- ⚠️ `npx markdownlint "docs/ADR-0001__central-cli-contract.de.md" "docs/Runbook.en.md" README.md` *(fails: npm registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da63c2b9d8832ca09b450242727f48