### PR TITLE
Expand bats assert helper implementation

### DIFF
--- a/tests/test_helper/bats-assert/load
+++ b/tests/test_helper/bats-assert/load
@@ -85,6 +85,12 @@ assert_line() {
   while (($#)); do
     case "$1" in
       --index)
+        if [[ -z $2 ]]; then
+          _assert_fail "Missing value for --index argument"
+        fi
+        if ! [[ $2 =~ ^[0-9]+$ ]]; then
+          _assert_fail "Invalid value for --index: '$2' (must be a non-negative integer)"
+        fi
         index=$2
         shift 2
         ;;


### PR DESCRIPTION
## Summary
- expand the custom bats-assert helper to implement success, failure, output, and line assertions
- provide clearer failure messages and support for partial and regex matching used in the test suite

## Testing
- `bash -n tests/test_helper/bats-assert/load`


------
https://chatgpt.com/codex/tasks/task_e_68da656ed6e8832c8219a669739734ef