### PR TITLE
Fix markdownlint spacing issues

### DIFF
--- a/docs/ADR-0001__central-cli-contract.en.md
+++ b/docs/ADR-0001__central-cli-contract.en.md
@@ -3,20 +3,25 @@
 > German version: [ADR-0001__central-cli-contract.de.md](ADR-0001__central-cli-contract.de.md)
 
 ## Status
+
 Accepted
 
 ## Context
+
 The wgx toolchain supports multiple projects and workstations. Until now, different variants of the CLI contract lived in individual repositories, leading to inconsistent behaviour and repeated coordination effort. New features had to be documented and agreed upon multiple times, and automated tests could not be reused reliably. On top of that, engineers work from different environments (Termux, VS Code Remote, traditional Linux setups), which makes configuration drift in the CLI a common source of errors.
 
 ## Decision
+
 We maintain a centrally governed CLI contract within wgx. The contract is versioned in `docs`, describes expected commands, configuration files (for example `profile.yml`), and their interfaces, and serves as the reference for all dependent projects. Contract changes must go through pull requests, including an ADR update, so that transparency and traceability are ensured.
 
 ## Consequences
+
 - Consistent behaviour: all projects align to the same contract and can ship compatible tooling scripts.
 - Less coordination overhead: documentation, tests, and runbooks only need to be maintained once.
 - Faster onboarding: new team members get a single reference point.
 - Higher maintainability: incompatible changes are detected early because they must be negotiated via the central contract.
 
 ## Open Questions
+
 - How do we migrate legacy projects that still maintain their own CLI definitions?
 - Which automated validations must run when the contract changes?

--- a/docs/Runbook.de.md
+++ b/docs/Runbook.de.md
@@ -3,6 +3,7 @@
 > Englische Version: [Runbook.en.md](Runbook.en.md)
 
 ## Quick-Links
+
 - Contract-Kompatibilität prüfen: `wgx validate`
 - Linting ausführen (auch für Git-Hooks): `wgx lint`
 - Umgebung diagnostizieren: `wgx doctor`
@@ -10,26 +11,31 @@
 ## Häufige Fehler und Lösungen
 
 ### `profile.yml` wird nicht gefunden
+
 - Prüfen, ob das Arbeitsverzeichnis korrekt gesetzt ist (z. B. Projektwurzel).
 - Mit `wgx profile list` sicherstellen, dass das Profil geladen werden kann.
 - Falls mehrere Profile vorhanden sind, den Pfad per `WGX_PROFILE_PATH` explizit setzen.
 
 ### `wgx`-Befehl schlägt mit Python-Fehlern fehl
+
 - Python-Umgebung aktivieren (`.venv/bin/activate` oder `pipx run`).
 - Fehlende Abhängigkeiten mit `pip install -r requirements.txt` nachinstallieren.
 - Bei globaler Installation prüfen, ob Version mit zentralem Contract kompatibel ist.
 
 ### Git-Hooks blockieren Commits
+
 - `wgx lint` manuell ausführen, um Fehler zu sehen.
 - Falls Hook veraltet ist, Repository aktualisieren und `wgx setup` erneut laufen lassen.
 
 ## Tipps für Termux
+
 - Termux-Repo aktualisieren (`pkg update`), bevor Python/Node installiert wird.
 - Essentials installieren: `pkg install jq git python`.
 - `pipx` ergänzen (`pip install pipx && pipx ensurepath`), um `wgx` isoliert zu nutzen.
 - Speicherzugriff auf das Projektverzeichnis gewähren (`termux-setup-storage`).
 
 ## Tipps für VS Code (Remote / Dev Containers)
+
 - Die `profile.yml` als Workspace-File markieren, damit Änderungen synchronisiert werden.
 - Aufgaben (`wgx`-Tasks) als VS Code Tasks integrieren, um Befehle mit einem Klick zu starten.
 - Bei Dev Containers sicherstellen, dass das Volume die `~/.wgx`-Konfiguration persistiert, z. B.:


### PR DESCRIPTION
## Summary
- add missing blank lines around headings in the ADR to satisfy markdownlint
- ensure runbook headings are separated from lists to comply with linting rules

## Testing
- not run (markdownlint-cli2 not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68da6a81e988832ca3cdccb6cfa0bfcf