### PR TITLE
Fix setup script case handling for install targets

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -92,7 +92,10 @@ collect_packages() {
   local -a packages=()
   for target in "$@"; do
     case "$target" in
-      "")
+      '')
+        ;;
+      check)
+        echo "Ignoring 'check' target during installation. Run './.devcontainer/setup.sh check' separately." >&2
         ;;
       base)
         packages+=("${BASE_PACKAGES[@]}")
@@ -156,7 +159,7 @@ run_install() {
 
 main() {
   case "${1-}" in
-    "")
+    '')
       usage
       exit 1
       ;;


### PR DESCRIPTION
## Summary
- normalize the install target case statement and ignore the check target during installation
- keep the main command dispatcher consistent when handling empty input

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da6d98fbd0832cb69d31e6e1b625f2