### PR TITLE
Fix install target handling in devcontainer setup script

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -142,13 +142,7 @@ run_install() {
   local -a targets_raw=()
   mapfile -t targets_raw < <(collect_packages "$@")
 
-  local -a targets=()
-  local pkg
-  for pkg in "${targets_raw[@]}"; do
-    if [[ -n "$pkg" ]]; then
-      targets+=("$pkg")
-    fi
-  done
+  local -a targets=("${targets_raw[@]}")
 
   if ((${#targets[@]} == 0)); then
     if ((default_to_base)); then


### PR DESCRIPTION
## Summary
- avoid defaulting to the base package group when install targets resolve to nothing
- treat empty install invocations as a request for the base packages while allowing ignored targets like `check` to exit cleanly

## Testing
- .devcontainer/setup.sh install check

------
https://chatgpt.com/codex/tasks/task_e_68da7eb927f0832c870481d48c67435f