### PR TITLE
Fix check target handling in devcontainer setup script

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -111,9 +111,6 @@ collect_packages() {
       jq|moreutils|shellcheck|shfmt|bats)
         packages+=("$target")
         ;;
-      check)
-        echo "Ignoring 'check' target during installation. Run './.devcontainer/setup.sh check' separately." >&2
-        ;;
       *)
         echo "Unknown install target: $target" >&2
         exit 1
@@ -121,7 +118,9 @@ collect_packages() {
     esac
   done
 
-  printf '%s\n' "${packages[@]}"
+  if ((${#packages[@]} > 0)); then
+    printf '%s\n' "${packages[@]}"
+  fi
 }
 
 run_check() {


### PR DESCRIPTION
## Summary
- de-duplicate the `check` case in `collect_packages` so the target is ignored cleanly during installation
- avoid emitting empty package entries when the target list is empty to prevent bad array subscripts

## Testing
- ./.devcontainer/setup.sh install check

------
https://chatgpt.com/codex/tasks/task_e_68da83ecb0f8832cafb990b5b01f93a9