### PR TITLE
Fix setup target handling and CLI dispatch

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -90,41 +90,39 @@ print_tool_status() {
 }
 
 collect_packages() {
+  local -n _out=$1
+  shift || true
+
   local target
-  local -a packages=()
   for target in "$@"; do
     case "$target" in
       '')
-        ;;
-      check)
-        echo "Ignoring 'check' target during installation. Run './.devcontainer/setup.sh check' separately." >&2
-        ;;
-      base)
-        packages+=("${BASE_PACKAGES[@]}")
-        ;;
-      optional)
-        packages+=("${OPTIONAL_PACKAGES[@]}")
-        ;;
-      all)
-        packages+=("${BASE_PACKAGES[@]}" "${OPTIONAL_PACKAGES[@]}")
-        ;;
-      jq|moreutils|shellcheck|shfmt|bats)
-        packages+=("$target")
+        continue
         ;;
       check)
         echo "Ignoring 'check' target during installation. Run './.devcontainer/setup.sh check' separately." >&2
         continue
         ;;
+      base)
+        _out+=("${BASE_PACKAGES[@]}")
+        ;;
+      optional)
+        _out+=("${OPTIONAL_PACKAGES[@]}")
+        ;;
+      all)
+        _out+=("${BASE_PACKAGES[@]}" "${OPTIONAL_PACKAGES[@]}")
+        ;;
+      jq|moreutils|shellcheck|shfmt|bats)
+        _out+=("$target")
+        ;;
       *)
         echo "Unknown install target: $target" >&2
-        exit 1
+        return 1
         ;;
     esac
   done
 
-  if ((${#packages[@]} > 0)); then
-    printf '%s\n' "${packages[@]}"
-  fi
+  return 0
 }
 
 run_check() {
@@ -146,7 +144,15 @@ run_install() {
     default_to_base=1
   fi
 
-  mapfile -t targets < <(collect_packages "$@")
+  local -a collected=()
+  if ! collect_packages collected "$@"; then
+    return 1
+  fi
+
+  local -a targets=()
+  if ((${#collected[@]} > 0)); then
+    targets=("${collected[@]}")
+  fi
 
   if ((${#targets[@]} == 0)); then
     if ((default_to_base)); then

--- a/cli/wgx
+++ b/cli/wgx
@@ -16,7 +16,9 @@ export WGX_DIR
 if [ -d "$WGX_DIR/lib" ]; then
   for f in "$WGX_DIR/lib/"*.bash; do
     if [ -r "$f" ]; then
-      echo "Loading library: $f" >&2
+      if [[ ${WGX_DEBUG:-0} != 0 ]]; then
+        echo "Loading library: $f" >&2
+      fi
       if ! source "$f"; then
         echo "Error: Failed to source library file: $f" >&2
         exit 1

--- a/lib/core.bash
+++ b/lib/core.bash
@@ -151,7 +151,12 @@ USAGE
 
 # ── Command dispatcher ──────────────────────────────────────────────────────
 wgx_main() {
-  local sub="${1:-help}"
+  if (($# == 0)); then
+    wgx_usage
+    return 1
+  fi
+
+  local sub="$1"
   shift || true
 
   case "$sub" in
@@ -164,11 +169,11 @@ wgx_main() {
     ;;
   help | -h | --help)
     wgx_usage
-    return
+    return 0
     ;;
   --list | commands)
     wgx_available_commands
-    return
+    return 0
     ;;
   esac
 
@@ -196,6 +201,7 @@ wgx_main() {
     return
   fi
 
-  echo "❌ Unbekannter Befehl: ${sub}" >&2
-  return 127
+  echo "Unknown command: ${sub}" >&2
+  wgx_usage >&2
+  return 1
 }

--- a/modules/semver.bash
+++ b/modules/semver.bash
@@ -63,8 +63,10 @@ semver_in_caret_range() {
     local next_minor=$(( minor + 1 ))
     upper="0.${next_minor}.0"
   else
-    local next_patch=$(( _patch + 1 ))
-    upper="0.0.${next_patch}"
+    # For 0.0.x ranges we only allow patch updates, so we stop before the
+    # first minor release.
+    local next_minor=$(( minor + 1 ))
+    upper="0.${next_minor}.0"
   fi
 
   semver_ge "$have" "$lower" && semver_lt "$have" "$upper"


### PR DESCRIPTION
## Summary
- ensure the devcontainer setup script skips empty install targets, fails fast on unknown ones, and keeps target collection inside the parent shell
- quiet the CLI bootstrap unless WGX_DEBUG is enabled and tighten command dispatch to show usage for missing or unknown commands
- adjust caret range handling so ^0.0.x ranges continue to allow patch updates while blocking the next minor

## Testing
- bash -lc 'source modules/semver.bash; semver_in_caret_range 0.0.5 ^0.0.3; echo status:$?'
- bash -lc 'source modules/semver.bash; semver_in_caret_range 0.1.0 ^0.0.3; echo status:$?'
- bash .devcontainer/setup.sh install

------
https://chatgpt.com/codex/tasks/task_e_68da85d058d8832ca0747344806a8b2e