### PR TITLE
Fix caret range handling for patch-only semver ranges

### DIFF
--- a/modules/semver.bash
+++ b/modules/semver.bash
@@ -51,8 +51,8 @@ semver_lt() {
 semver_in_caret_range() {
   local have="${1#v}" range="${2#^}"
   range="$(semver_norm "$range")"
-  local major minor _patch
-  IFS='.' read -r major minor _patch <<<"$range"
+  local major minor patch
+  IFS='.' read -r major minor patch <<<"$range"
   local lower="$range"
   local upper
 
@@ -63,10 +63,10 @@ semver_in_caret_range() {
     local next_minor=$(( minor + 1 ))
     upper="0.${next_minor}.0"
   else
-    # For 0.0.x ranges, we set the upper bound at the next minor version (0.${next_minor}.0),
-    # so only patch updates within the current minor version are allowed, and we stop before the first minor release.
-    local next_minor=$(( minor + 1 ))
-    upper="0.${next_minor}.0"
+    # For 0.0.x ranges, caret semantics allow patch updates only, stopping before the next
+    # patch release (e.g. ^0.0.3 allows versions >=0.0.3 and <0.0.4).
+    local next_patch=$(( patch + 1 ))
+    upper="0.0.${next_patch}"
   fi
 
   semver_ge "$have" "$lower" && semver_lt "$have" "$upper"

--- a/tests/semver.bats
+++ b/tests/semver.bats
@@ -21,8 +21,8 @@ setup() {
 }
 
 @test "caret range pins zero major zero minor to next patch" {
-  run semver_in_caret_range "0.0.5" "^0.0.3"
+  run semver_in_caret_range "0.0.3" "^0.0.3"
   assert_success
-  run semver_in_caret_range "0.1.0" "^0.0.3"
+  run semver_in_caret_range "0.0.4" "^0.0.3"
   assert_failure
 }


### PR DESCRIPTION
## Summary
- adjust caret range logic so ^0.0.x ranges stop at the next patch release instead of the next minor release
- update the caret-range unit test to reflect the corrected upper bound

## Testing
- bash -lc 'source modules/semver.bash; semver_in_caret_range 0.0.3 ^0.0.3; echo $?'
- bash -lc 'source modules/semver.bash; semver_in_caret_range 0.0.4 ^0.0.3; echo $?'
- ⚠️ bats tests/semver.bats (not run: Bats unavailable in the environment due to apt repository 403 errors)


------
https://chatgpt.com/codex/tasks/task_e_68dad70e0fd0832c906ca929c34f26c8