### PR TITLE
Fix semver caret Bats helper loading

### DIFF
--- a/tests/semver_caret.bats
+++ b/tests/semver_caret.bats
@@ -1,8 +1,9 @@
 #!/usr/bin/env bats
 
 setup() {
-  load 'test_helper/bats-support/load'
-  load 'test_helper/bats-assert/load'
+  TEST_HELPER_DIR="$BATS_TEST_DIRNAME/test_helper"
+  load "$TEST_HELPER_DIR/bats-support/load"
+  load "$TEST_HELPER_DIR/bats-assert/load"
   source "$PWD/modules/semver.bash"
 }
 


### PR DESCRIPTION
## Summary
- load the bats-support and bats-assert helpers in `tests/semver_caret.bats`
- invoke `semver_in_caret_range` directly so the helper assertions work

## Testing
- `bats tests/semver_caret.bats` *(fails: bats not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dadabecb0c832ca94a751e18d7a0cb