### PR TITLE
Fix semver caret test helper paths

### DIFF
--- a/tests/semver_caret.bats
+++ b/tests/semver_caret.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
-load 'test/bats-support/load'
-load 'test/bats-assert/load'
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
 
 setup() { source modules/semver.bash; }
 


### PR DESCRIPTION
## Summary
- update the semver caret test to load helpers from the existing test_helper directory

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68dadb19c334832c819bc5f1f337d8c1