### PR TITLE
Fix semver caret tests helper path

### DIFF
--- a/tests/semver_caret.bats
+++ b/tests/semver_caret.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
-load 'test/bats-support/load'
-load 'test/bats-assert/load'
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
 
 setup() { source modules/semver.bash; }
 


### PR DESCRIPTION
## Summary
- load bats-support and bats-assert helpers from the existing test_helper directory in the semver caret tests

## Testing
- not run (bats not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dadb9b15d0832ca120bbd23b680717