### PR TITLE
Fix semver caret Bats tests to source helper functions

### DIFF
--- a/tests/semver_caret.bats
+++ b/tests/semver_caret.bats
@@ -1,32 +1,35 @@
 #!/usr/bin/env bats
 
-load 'test_helper/bats-support/load'
-load 'test_helper/bats-assert/load'
-
-setup() { source modules/semver.bash; }
+setup() {
+  load 'test_helper/bats-support/load'
+  load 'test_helper/bats-assert/load'
+  # Load the semver helpers from the repository root so the functions are
+  # available directly to the test process.
+  source "$PWD/modules/semver.bash"
+}
 
 @test "^0.0.3 allows 0.0.3 and <0.0.4" {
-  run bash -lc 'semver_in_caret_range 0.0.3 ^0.0.3'
+  run semver_in_caret_range "0.0.3" "^0.0.3"
   assert_success
-  run bash -lc 'semver_in_caret_range 0.0.4 ^0.0.3'
+  run semver_in_caret_range "0.0.4" "^0.0.3"
   assert_failure
 }
 
 @test "^0.2.5 allows <0.3.0" {
-  run bash -lc 'semver_in_caret_range 0.2.9 ^0.2.5'
+  run semver_in_caret_range "0.2.9" "^0.2.5"
   assert_success
-  run bash -lc 'semver_in_caret_range 0.3.0 ^0.2.5'
+  run semver_in_caret_range "0.3.0" "^0.2.5"
   assert_failure
 }
 
 @test "^1.2.3 allows <2.0.0" {
-  run bash -lc 'semver_in_caret_range 1.9.9 ^1.2.3'
+  run semver_in_caret_range "1.9.9" "^1.2.3"
   assert_success
-  run bash -lc 'semver_in_caret_range 2.0.0 ^1.2.3'
+  run semver_in_caret_range "2.0.0" "^1.2.3"
   assert_failure
 }
 
 @test "v-prefixed versions are accepted" {
-  run bash -lc 'semver_in_caret_range v1.2.3 ^1.2.0'
+  run semver_in_caret_range "v1.2.3" "^1.2.0"
   assert_success
 }


### PR DESCRIPTION
## Summary
- ensure the semver caret tests load the Bats helpers in setup
- source the semver module from the repository root so functions are defined
- run semver_in_caret_range directly instead of spawning a new shell

## Testing
- bats tests/semver_caret.bats *(fails: bats command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dadc5987d8832cbfc66122ae7feac7