### PR TITLE
Align semver caret helper loading

### DIFF
--- a/tests/semver_caret.bats
+++ b/tests/semver_caret.bats
@@ -1,32 +1,33 @@
 #!/usr/bin/env bats
 
-load 'test/bats-support/load'
-load 'test/bats-assert/load'
-
-setup() { source modules/semver.bash; }
+setup() {
+  load 'test_helper/bats-support/load'
+  load 'test_helper/bats-assert/load'
+  source "$PWD/modules/semver.bash"
+}
 
 @test "^0.0.3 allows 0.0.3 and <0.0.4" {
-  run bash -lc 'semver_in_caret_range 0.0.3 ^0.0.3'
+  run semver_in_caret_range "0.0.3" "^0.0.3"
   assert_success
-  run bash -lc 'semver_in_caret_range 0.0.4 ^0.0.3'
+  run semver_in_caret_range "0.0.4" "^0.0.3"
   assert_failure
 }
 
 @test "^0.2.5 allows <0.3.0" {
-  run bash -lc 'semver_in_caret_range 0.2.9 ^0.2.5'
+  run semver_in_caret_range "0.2.9" "^0.2.5"
   assert_success
-  run bash -lc 'semver_in_caret_range 0.3.0 ^0.2.5'
+  run semver_in_caret_range "0.3.0" "^0.2.5"
   assert_failure
 }
 
 @test "^1.2.3 allows <2.0.0" {
-  run bash -lc 'semver_in_caret_range 1.9.9 ^1.2.3'
+  run semver_in_caret_range "1.9.9" "^1.2.3"
   assert_success
-  run bash -lc 'semver_in_caret_range 2.0.0 ^1.2.3'
+  run semver_in_caret_range "2.0.0" "^1.2.3"
   assert_failure
 }
 
 @test "v-prefixed versions are accepted" {
-  run bash -lc 'semver_in_caret_range v1.2.3 ^1.2.0'
+  run semver_in_caret_range "v1.2.3" "^1.2.0"
   assert_success
 }


### PR DESCRIPTION
## Summary
- load bats helper libraries using the same relative paths as other tests to ensure compatibility
- keep sourcing the semver module from the repository root and invoking semver_in_caret_range directly

## Testing
- `bats tests/semver_caret.bats` *(fails: command not found: bats)*

------
https://chatgpt.com/codex/tasks/task_e_68dadc26496c832c94434e5680a1781d