### PR TITLE
Add VS Code tasks for common shell tooling

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,9 +1,37 @@
 {
   "version": "2.0.0",
   "tasks": [
-    { "label": "shfmt: diff",   "type": "shell", "command": "shfmt -d $(git ls-files '*.sh' '*.bash')" },
-    { "label": "shellcheck",    "type": "shell", "command": "shellcheck -S style $(git ls-files '*.sh' '*.bash')" },
-    { "label": "bats: tests",   "type": "shell", "command": "bats -r tests" },
-    { "label": "wgx: validate", "type": "shell", "command": "wgx validate" }
+    {
+      "label": "shfmt: diff",
+      "type": "shell",
+      "command": "shfmt -d $(git ls-files '*.sh' '*.bash' || echo '')",
+      "options": { "cwd": "${workspaceFolder}" },
+      "group": "build",
+     "problemMatcher": []
+    },
+    {
+      "label": "shellcheck",
+      "type": "shell",
+      "command": "shellcheck -S style $(git ls-files '*.sh' '*.bash' || echo '')",
+      "options": { "cwd": "${workspaceFolder}" },
+      "group": "build",
+      "problemMatcher": []
+    },
+    {
+      "label": "bats: tests",
+      "type": "shell",
+      "command": "bats -r tests",
+      "options": { "cwd": "${workspaceFolder}" },
+      "group": "test",
+      "problemMatcher": []
+    },
+    {
+      "label": "wgx: validate",
+      "type": "shell",
+      "command": "wgx validate",
+      "options": { "cwd": "${workspaceFolder}" },
+      "group": "test",
+      "problemMatcher": []
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- add VS Code task definitions for shfmt, shellcheck, bats, and wgx validate

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daed3d0e88832cb7036aa2d43b2fd1