### PR TITLE
Update bats action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run bats test suites
-        uses: bats-core/bats-action@v2.0.0
+        uses: bats-core/bats-action@v2.1.0
         with:
           helpers: |
             bats-support


### PR DESCRIPTION
## Summary
- bump the bats-core/bats-action used in the CI workflow to v2.1.0 so the action can be resolved

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dbcc1b1404832cb3699ff00124fe77