### PR TITLE
Scope docs and shell linting to changed files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
             echo "No Markdown files to lint."
             exit 0
           fi
-          markdownlint-cli2 $files
+          markdownlint-cli2 "$files"
       - name: Vale lint (changed only)
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- scope the shell lint workflow to the shell files that actually changed while keeping full runs for merge_group, workflow dispatch, and force labels
- limit Vale, Markdownlint, and Lychee to changed documentation files and add npm caching for faster reruns

## Testing
- not run (CI only)

------
https://chatgpt.com/codex/tasks/task_e_68dbe4464cd0832c983477d7038d7846