### PR TITLE
Add lint command implementation and guard detection fixes

### DIFF
--- a/cmd/lint.bash
+++ b/cmd/lint.bash
@@ -1,7 +1,50 @@
 #!/usr/bin/env bash
 
 cmd_lint() {
-  lint_cmd "$@"
+  local base_dir="${WGX_DIR:-"$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"}"
+  local -a shell_files=()
+
+  if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    while IFS= read -r -d '' file; do
+      shell_files+=("$file")
+    done < <(git ls-files -z -- '*.sh' '*.bash' 'wgx' 'cli/wgx')
+  else
+    while IFS= read -r -d '' file; do
+      case "$file" in
+      "${base_dir}/"*) shell_files+=("${file#"${base_dir}/"}") ;;
+      *) shell_files+=("$file") ;;
+      esac
+    done < <(find "$base_dir" -type f \( -name '*.sh' -o -name '*.bash' -o -name 'wgx' -o -path "${base_dir}/cli/wgx" \) -print0)
+  fi
+
+  if [ ${#shell_files[@]} -eq 0 ]; then
+    warn "No shell scripts found to lint."
+    return 0
+  fi
+
+  local rc=0
+
+  if command -v shfmt >/dev/null 2>&1; then
+    if ! shfmt -d "${shell_files[@]}"; then
+      rc=1
+    fi
+  else
+    warn "shfmt not found, skipping formatting check."
+  fi
+
+  if command -v shellcheck >/dev/null 2>&1; then
+    if ! shellcheck -S style "${shell_files[@]}"; then
+      rc=1
+    fi
+  else
+    warn "shellcheck not found, skipping lint step."
+  fi
+
+  return $rc
+}
+
+lint_cmd() {
+  cmd_lint "$@"
 }
 
 wgx_command_main() {

--- a/modules/guard.bash
+++ b/modules/guard.bash
@@ -2,6 +2,15 @@
 
 # Guard-Modul: Lint- und Testläufe (aus Monolith portiert)
 
+_guard_command_available() {
+  local name="$1"
+  if declare -F "cmd_${name}" >/dev/null 2>&1; then
+    return 0
+  fi
+  local base_dir="${WGX_DIR:-"$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"}"
+  [[ -r "${base_dir}/cmd/${name}.bash" ]]
+}
+
 guard_run() {
   local run_lint=0 run_test=0
   while [[ $# -gt 0 ]]; do
@@ -45,7 +54,7 @@ guard_run() {
 
   # 4. Lint (wenn gewünscht)
   if [[ $run_lint -eq 1 ]]; then
-    if command -v lint_cmd >/dev/null 2>&1 || command -v cmd_lint >/dev/null 2>&1; then
+    if _guard_command_available lint; then
       echo "▶ Running lint checks..."
       ./wgx lint || return 1
     else
@@ -55,7 +64,7 @@ guard_run() {
 
   # 5. Tests (wenn gewünscht)
   if [[ $run_test -eq 1 ]]; then
-    if command -v test_cmd >/dev/null 2>&1 || command -v cmd_test >/dev/null 2>&1; then
+    if _guard_command_available test; then
       echo "▶ Running tests..."
       ./wgx test || return 1
     else


### PR DESCRIPTION
## Summary
- implement `wgx lint` to collect repository shell scripts and run shfmt/shellcheck when available
- add compatibility alias for `lint_cmd` while reusing the same implementation for command dispatch
- improve the guard module so it detects lint/test availability by checking command files before invoking them

## Testing
- ./wgx lint
- ./wgx guard --lint

------
https://chatgpt.com/codex/tasks/task_e_68dbf43db6e8832c9e834a34ed3528ec