### PR TITLE
Fix bats action version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run bats test suites
-        uses: bats-core/bats-action@v2
+        uses: bats-core/bats-action@v1
         with:
           helpers: |
             bats-support


### PR DESCRIPTION
## Summary
- update the CI workflow to reference the published bats-core/bats-action@v1 tag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcbd5f0a94832ca16b1015b89e8363