### PR TITLE
Remove blank line in fallback info section

### DIFF
--- a/modules/status.bash
+++ b/modules/status.bash
@@ -65,7 +65,6 @@ status_cmd() {
     fi
 
     if [ "$fallback_present" = "1" ]; then
-
       info_present=1
     fi
   fi


### PR DESCRIPTION
## Summary
- remove the extra blank line in the fallback project section of the status module

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcce8fd820832cbeb0d99ac81a98d6