### PR TITLE
Clarify sync abort marker

### DIFF
--- a/modules/sync.bash
+++ b/modules/sync.bash
@@ -46,7 +46,7 @@ sync_cmd() {
         done <<<"$status"
       fi
       warn "Nutze 'wgx sync --force', wenn du trotzdem fortfahren willst (Änderungen werden ggf. gestasht)."
-      # Maschinenlesbarer Marker für Aufrufer.
+      # Maschinenlesbarer Marker für aufrufende Prozesse.
       printf 'sync abgebrochen\n'
       return 1
     fi


### PR DESCRIPTION
## Summary
- document the lower-case "sync abgebrochen" line as an explicit machine-readable marker

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcce724364832c921b360acb0a4b8b