### PR TITLE
Update bats GitHub Action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run bats test suites
-        uses: bats-core/bats-action@v1
+        uses: bats-core/bats-action@v2
         with:
           helpers: |
             bats-support


### PR DESCRIPTION
## Summary
- update the Bats workflow step to use the maintained v2 release of bats-core/bats-action

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd432a49e4832c9820d1c1c961680b