### PR TITLE
Use English wording for sync option error

### DIFF
--- a/modules/sync.bash
+++ b/modules/sync.bash
@@ -19,7 +19,7 @@ sync_cmd() {
       break
       ;;
     -*)
-      printf 'sync: unbekannte Option %s\n' "$1" >&2
+      printf 'sync: unknown option %s\n' "$1" >&2
       return 2
       ;;
     *)


### PR DESCRIPTION
## Summary
- update the unknown option error in `wgx sync` to use English wording for consistency

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd4374c0c0832c8436611040accbb2