### PR TITLE
Add checksum verification to Vale installer in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
         run: |
           set -euo pipefail
           curl --retry 5 --retry-all-errors -fsSL "https://github.com/errata-ai/vale/releases/download/${VALE_VERSION}/vale_Linux_64-bit.tar.gz" -o vale.tar.gz
-          curl --retry 5 --retry-all-errors -fsSL "https://github.com/errata-ai/vale/releases/download/${VALE_VERSION}/vale_${VALE_VERSION#v}_checksums.txt" -o checksums.txt
+          curl --retry 5 --retry-all-errors -fsSL "https://github.com/errata-ai/vale/releases/download/${VALE_VERSION}/checksums.txt" -o checksums.txt
           EXPECTED_SHA256=$(awk '$2 == "vale_Linux_64-bit.tar.gz" {print $1; exit}' checksums.txt)
           if [[ -z "${EXPECTED_SHA256:-}" ]]; then
             echo "Unable to determine expected checksum for vale_Linux_64-bit.tar.gz" >&2


### PR DESCRIPTION
## Summary
- verify the downloaded Vale release tarball against its published checksum before extraction in CI

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68dd45c53214832cb355ab288884a868