### PR TITLE
Pin bats GitHub Action to supported version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run bats test suites
+        # Pin to v2 because bats-core/bats-action does not publish a v1 release.
         uses: bats-core/bats-action@v2
         with:
           helpers: |


### PR DESCRIPTION
## Summary
- document in CI workflow why bats-core/bats-action is pinned to the supported v2 release

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd46133864832cbee0b0c1d322ac96