### PR TITLE
Fix sync argument parsing for unknown options

### DIFF
--- a/modules/sync.bash
+++ b/modules/sync.bash
@@ -10,23 +10,24 @@ sync_cmd() {
     case "$1" in
     --force|-f)
       force=1
+      shift
       ;;
     --dry-run|-n)
       dry_run=1
+      shift
       ;;
     --)
       shift
       break
       ;;
     -*)
-      printf 'sync: unknown option %s\n' "$1" >&2
-      return 2
+      printf 'sync: unbekannte Option %s\n' "$1" >&2
+      return 123
       ;;
     *)
       break
       ;;
     esac
-    shift
   done
 
   local base="${1:-$WGX_BASE}"


### PR DESCRIPTION
## Summary
- adjust `wgx sync` argument parsing to shift handled options inside the case block
- return exit code 123 and german error message for unknown options to match expectations

## Testing
- shellcheck modules/sync.bash *(fails: shellcheck not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd463b2494832cb0223694c22fd2fd