### PR TITLE
Fix bats action version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,8 +160,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run bats test suites
-        # Pin to v2 because bats-core/bats-action does not publish a v1 release.
-        uses: bats-core/bats-action@v2
+        # Pin to v1.6.0, the latest published release of bats-core/bats-action.
+        uses: bats-core/bats-action@v1.6.0
         with:
           helpers: |
             bats-support


### PR DESCRIPTION
## Summary
- pin the bats-core/bats-action step in the CI workflow to the latest v1 release tag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd47dd7d14832ca7f9cc154b6f4b12