### PR TITLE
Update bats GitHub Action to v1.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,8 +160,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run bats test suites
-        # Pin to v1.6.0, the latest published release of bats-core/bats-action.
-        uses: bats-core/bats-action@v1.6.0
+        # Pin to v1.8.0, the latest published release of bats-core/bats-action.
+        uses: bats-core/bats-action@v1.8.0
         with:
           helpers: |
             bats-support


### PR DESCRIPTION
## Summary
- bump the bats-core/bats-action used in the CI workflow from v1.6.0 to v1.8.0 to reference an existing release

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd4b434998832ca60b341a2c425764