### PR TITLE
feat(sync): support base option

### DIFF
--- a/modules/sync.bash
+++ b/modules/sync.bash
@@ -5,7 +5,7 @@ sync_cmd() {
     die "Bitte innerhalb eines Git-Repositories ausführen (kein Git-Repository erkannt)."
   fi
 
-  local force=0 dry_run=0
+  local force=0 dry_run=0 base_override=""
   while [ $# -gt 0 ]; do
     case "$1" in
     --force|-f)
@@ -14,6 +14,19 @@ sync_cmd() {
       ;;
     --dry-run|-n)
       dry_run=1
+      shift
+      ;;
+    --base)
+      shift
+      if [ $# -eq 0 ]; then
+        printf 'sync: option --base requires an argument\n' >&2
+        return 123
+      fi
+      base_override="$1"
+      shift
+      ;;
+    --base=*)
+      base_override="${1#*=}"
       shift
       ;;
     --)
@@ -30,7 +43,12 @@ sync_cmd() {
     esac
   done
 
-  local base="${1:-$WGX_BASE}"
+  local base
+  if [ -n "$base_override" ]; then
+    base="$base_override"
+  else
+    base="${1:-$WGX_BASE}"
+  fi
   [ -z "$base" ] && base="main"
 
   if git_workdir_dirty; then

--- a/tests/sync.bats
+++ b/tests/sync.bats
@@ -46,3 +46,9 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" =~ "[DRY-RUN]" ]]
 }
+
+@test "sync --dry-run accepts --base option" {
+  run wgx sync --dry-run --base develop
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "git fetch origin develop" ]]
+}


### PR DESCRIPTION
## Summary
- allow the sync command to accept a --base argument (with optional = syntax)
- ensure dry-run output reflects the chosen base branch
- add a regression test covering the new flag

## Testing
- `bats tests/sync.bats` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4b7e69c4832c9f7d12ab58cdb1e4