### PR TITLE
Clarify run-with-files usage documentation

### DIFF
--- a/etc/ci/run-with-files.sh
+++ b/etc/ci/run-with-files.sh
@@ -5,8 +5,11 @@ usage() {
   cat <<'USAGE' >&2
 Usage: run-with-files.sh [--per-file] <empty-message> <command> [args...]
 
-Reads a list of file paths from standard input (one per line), filters out
-empty entries, and executes the provided command with the resulting files.
+Reads file paths (one per line) from standard input, filters out empty entries,
+and executes the provided command with the resulting list of files.
+
+Without --per-file the command is run once with all files as arguments. When
+--per-file is supplied the command is invoked separately for each file.
 USAGE
 }
 


### PR DESCRIPTION
## Summary
- clarify the usage message for run-with-files.sh
- explain that file paths are read from stdin and how the --per-file flag behaves

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd4c673898832ca03b179b657427dd