### PR TITLE
Handle sync --base override in dry-run

### DIFF
--- a/modules/sync.bash
+++ b/modules/sync.bash
@@ -22,13 +22,14 @@ sync_cmd() {
       shift
       if [ $# -eq 0 ]; then
         printf 'sync: option --base requires an argument\n' >&2
-        return 2
+        return 123
       fi
       base_override="$1"
       shift
       ;;
     --base=*)
       base_override="${1#--base=}"
+      shift
       ;;
     --)
       shift

--- a/tests/sync.bats
+++ b/tests/sync.bats
@@ -65,3 +65,9 @@ teardown() {
   [[ "$output" =~ "origin/trunk" ]]
   [[ "$output" =~ "überschreibt den angegebenen Branch" ]]
 }
+
+@test "sync --dry-run accepts --base option" {
+  run wgx sync --dry-run --base develop
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "git fetch origin develop" ]]
+}


### PR DESCRIPTION
## Summary
- ensure the sync command consumes inline --base arguments and aligns error codes
- warn when overriding a positional branch and honour the override in dry-run output
- add a regression test covering sync --dry-run with a custom base

## Testing
- `bats tests/sync.bats` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4da870b8832cb982862fe2dc42a6