### PR TITLE
Avoid empty Authorization header in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,13 +233,23 @@ EOF
           release_json=""
 
           # Use authenticated GitHub API requests to avoid low rate limits
-          auth_header="Authorization: Bearer ${GITHUB_TOKEN:-}"
           accept_header="Accept: application/vnd.github+json"
           api_ver_header="X-GitHub-Api-Version: 2022-11-28"
 
+          curl_headers=(
+            -H "$accept_header"
+            -H "$api_ver_header"
+          )
+
+          if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+            curl_headers+=(
+              -H "Authorization: Bearer ${GITHUB_TOKEN}"
+            )
+          fi
+
           if [[ -n "${version}" && "${version}" != "latest" ]]; then
             if ! release_json=$(curl --retry 5 --retry-all-errors -fsSL \
-              -H "$auth_header" -H "$accept_header" -H "$api_ver_header" \
+              "${curl_headers[@]}" \
               "https://api.github.com/repos/${owner}/${repo}/releases/tags/${version}"); then
               echo "Unable to fetch release metadata for ${version}; falling back to the latest release" >&2
               release_json=""
@@ -248,7 +258,7 @@ EOF
 
           if [[ -z "${release_json}" ]]; then
             release_json=$(curl --retry 5 --retry-all-errors -fsSL \
-              -H "$auth_header" -H "$accept_header" -H "$api_ver_header" \
+              "${curl_headers[@]}" \
               "https://api.github.com/repos/${owner}/${repo}/releases/latest")
             version=$(printf '%s' "${release_json}" | python3 - <<'PY'
 import json, sys


### PR DESCRIPTION
## Summary
- avoid passing an empty Authorization header when fetching Vale release metadata in CI by only adding the header when a GitHub token is available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd50772a28832cb7111f2b93577bcd