### PR TITLE
Adjust sync command exit codes for invalid arguments

### DIFF
--- a/modules/sync.bash
+++ b/modules/sync.bash
@@ -22,7 +22,7 @@ sync_cmd() {
       shift
       if [ $# -eq 0 ]; then
         printf 'sync: option --base requires an argument\n' >&2
-        return 123
+        return 2
       fi
       base_override="$1"
       shift
@@ -41,7 +41,7 @@ sync_cmd() {
       ;;
     -*)
       printf 'sync: unknown option %s\n' "$1" >&2
-      return 123
+      return 2
       ;;
     *)
       positional+=("$1")


### PR DESCRIPTION
## Summary
- replace the sync command's magic exit code with the conventional error code 2 when --base is missing its argument
- use the same exit code for unknown options to stay consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd50ab5ea0832cb8d8ceb1f94da1ba