### PR TITLE
Reduce timeout for bats tests

### DIFF
--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -57,7 +57,8 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Bail out proactively if the bats suite stops making progress.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Run bats tests


### PR DESCRIPTION
## Summary
- reduce the on-demand bats workflow timeout to 10 minutes to stop hung runs sooner

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd76ea1e8c832cac1cef6a13d57d6f