### PR TITLE
Fix sync positional argument parsing

### DIFF
--- a/modules/sync.bash
+++ b/modules/sync.bash
@@ -45,6 +45,7 @@ sync_cmd() {
       ;;
     *)
       positional+=("$1")
+      shift
       ;;
     esac
   done


### PR DESCRIPTION
## Summary
- ensure the sync command parser advances past positional arguments to avoid infinite loops
- allow combinations of positional branch names with options like --dry-run and --base to complete

## Testing
- ./wgx sync feature --dry-run --base trunk

------
https://chatgpt.com/codex/tasks/task_e_68de053bee8c832cb54f379d2f6aac36