### PR TITLE
Add assert_error helper to bats assertions shim

### DIFF
--- a/tests/test_helper/bats-assert/load
+++ b/tests/test_helper/bats-assert/load
@@ -79,6 +79,42 @@ assert_output() {
   fi
 }
 
+assert_error() {
+  local mode=exact
+  while (($#)); do
+    case "$1" in
+      --partial)
+        mode=partial
+        shift
+        ;;
+      --regexp)
+        mode=regexp
+        shift
+        ;;
+      --)
+        shift
+        break
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+
+  local expected="$*"
+
+  local actual=""
+  if [[ -n ${stderr+x} ]]; then
+    actual="$stderr"
+  elif [[ -n ${error+x} ]]; then
+    actual="$error"
+  fi
+
+  if ! _assert_match "$mode" "$actual" "$expected"; then
+    _assert_fail "Expected error (${mode}) to match '$expected' but was: $actual"
+  fi
+}
+
 assert_line() {
   local index=""
   local mode=exact


### PR DESCRIPTION
## Summary
- add an assert_error helper to the in-repo bats-assert shim so tests can assert stderr content

## Testing
- not run (bats is not installed in the container)


------
https://chatgpt.com/codex/tasks/task_e_68dfd9f8f740832cb5428360ac16cb15