### PR TITLE
Fix env doctor --fix stderr message outside Termux

### DIFF
--- a/modules/env.bash
+++ b/modules/env.bash
@@ -142,7 +142,7 @@ env::_apply_fixes() {
     return 1
   fi
 
-  printf '%s\n' "--fix is currently only supported on Termux" >&2
+  warn "--fix is currently only supported on Termux"
   return 0
 }
 


### PR DESCRIPTION
## Summary
- direct the Termux-only notice from `wgx env doctor --fix` to stderr when running outside Termux

## Testing
- bats tests/env.bats *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e109820c6c832c969c5bb861f05a40