### PR TITLE
Fix security workflow missing token

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,6 +39,8 @@ jobs:
       # Use pre-built action for cargo-audit to avoid repeated compilation
       - name: Audit dependencies
         uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       # Optional: falls du ein eigenes DB-Verzeichnis nutzt
       # - name: Audit with explicit DB path
       #   run: cargo audit -d ~/.cargo/advisory-db


### PR DESCRIPTION
## Summary
- add the required GitHub token input to the audit step in the security workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27806a5c8832c99d0f7e0719afad2