### PR TITLE
Update workflows for Heimgewebe repos and OIDC permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
+  id-token: write
   pull-requests: write
   contents: read
 
@@ -389,8 +390,8 @@ EOF
       fail-fast: false
       matrix:
         repo:
-          - https://github.com/alexdermohr/weltgewebe
-          - https://github.com/alexdermohr/hauski
+          - https://github.com/heimgewebe/weltgewebe
+          - https://github.com/heimgewebe/hausKI
           # ggf. weitere Repos ergänzen
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/compat-on-demand.yml
+++ b/.github/workflows/compat-on-demand.yml
@@ -8,8 +8,8 @@ on:
         required: false
         default: |
           [
-            {"repo":"alexdermohr/hauski","ref":"main"},
-            {"repo":"alexdermohr/weltgewebe","ref":"main"}
+            {"repo":"heimgewebe/hausKI","ref":"main"},
+            {"repo":"heimgewebe/weltgewebe","ref":"main"}
           ]
   pull_request:
     branches: [ main ]
@@ -17,6 +17,7 @@ on:
   merge_group: {}
 
 permissions:
+  id-token: write
   contents: read
 
 concurrency:
@@ -55,7 +56,7 @@ jobs:
       - id: matrix
         shell: bash
         run: |
-          def='[{"repo":"alexdermohr/hauski","ref":"main"},{"repo":"alexdermohr/weltgewebe","ref":"main"}]'
+          def='[{"repo":"heimgewebe/hausKI","ref":"main"},{"repo":"heimgewebe/weltgewebe","ref":"main"}]'
           inp=$(cat <<'JSON'
 ${{ github.event.inputs.targets_json }}
 JSON

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,5 +1,6 @@
 name: security
 permissions:
+  id-token: write
   contents: read
 
 on:

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -8,6 +8,7 @@ on:
   merge_group: {}
 
 permissions:
+  id-token: write
   contents: read
   pull-requests: read
 

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -1,5 +1,6 @@
 name: wgx-guard
 permissions:
+  id-token: write
   contents: read
 on:
   push:

--- a/cmd/validate.bash
+++ b/cmd/validate.bash
@@ -557,10 +557,10 @@ Validate the local manifest or additional repositories.
 Examples:
   wgx validate
   wgx validate ../weltgewebe ../hauski
-  wgx validate https://github.com/alexdermohr/weltgewebe
+  wgx validate https://github.com/heimgewebe/weltgewebe
   wgx validate --json -- \
-    https://github.com/alexdermohr/weltgewebe \
-    https://github.com/alexdermohr/hauski
+    https://github.com/heimgewebe/weltgewebe \
+    https://github.com/heimgewebe/hausKI
 USAGE
       return 0
       ;;


### PR DESCRIPTION
## Summary
- add id-token write permissions to GitHub workflows that require OIDC tokens
- update workflow matrix defaults to use the heimgewebe organization and the renamed hausKI repository

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4cb436ed4832c89a6818beab3d74b