### PR TITLE
fix: align CLI version constant

### DIFF
--- a/cli/wgx
+++ b/cli/wgx
@@ -13,7 +13,7 @@ WGX_DIR="$(cd -P "$(dirname "$SOURCE")/.." >/dev/null 2>&1 && pwd)"
 export WGX_DIR
 
 # Version anzeigen, bevor weitere Komponenten geladen werden
-__WGX_VERSION__="2.0.0"
+__WGX_VERSION__="2.0.3"
 export WGX_VERSION="$__WGX_VERSION__"
 case "${1:-}" in
   --version|-V)


### PR DESCRIPTION
## Summary
- update the CLI dispatcher to report version 2.0.3, matching the library default

## Testing
- ./cli/wgx version


------
https://chatgpt.com/codex/tasks/task_e_68e4fa59ae90832cb5698580b5a07381