### PR TITLE
Improve guard oversized file detection

### DIFF
--- a/modules/guard.bash
+++ b/modules/guard.bash
@@ -57,7 +57,9 @@ guard_run() {
 
   # 3. Bigfiles checken
   echo "▶ Checking for oversized files..."
-  if git ls-files -z | xargs -0 du -sh 2>/dev/null | grep -E '^[1-9][0-9]{2,}[KMG]'; then
+  if git ls-files -z \
+    | xargs -0 du -sb 2>/dev/null \
+    | awk 'BEGIN { found = 0 } $1 >= 1048576 { print; found = 1 } END { exit(found ? 0 : 1) }'; then
     echo "❌ Zu große Dateien im Repo!" >&2
     return 1
   fi

--- a/tests/guard.bats
+++ b/tests/guard.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+
+setup() {
+  load 'test_helper/bats-support/load'
+  load 'test_helper/bats-assert/load'
+  export WGX_DIR="$(pwd)"
+  export PATH="$WGX_DIR/cli:$PATH"
+}
+
+teardown() {
+  local bigfile="tmp_guard_bigfile"
+  git reset --quiet HEAD "$bigfile" >/dev/null 2>&1 || true
+  rm -f "$bigfile"
+}
+
+@test "guard fails on files >=1MB" {
+  local bigfile="tmp_guard_bigfile"
+  truncate -s 1M "$bigfile"
+  git add "$bigfile"
+
+  run wgx guard
+  assert_failure
+  assert_output --partial "Zu große Dateien"
+}


### PR DESCRIPTION
## Summary
- refine the guard oversized file check to evaluate exact byte sizes so decimal `du` output is detected
- add a Bats test that stages a ≥1 MB file and expects the guard to fail

## Testing
- bats tests/guard.bats *(fails: bats not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5218414ac832cae792f6defd9f144