### PR TITLE
Align UV handling across CI workflows

### DIFF
--- a/.github/workflows/shell-docs.yml
+++ b/.github/workflows/shell-docs.yml
@@ -64,14 +64,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install uv
         run: |
+          set -euo pipefail
           curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >>"$GITHUB_PATH"
+          uv_version="$($HOME/.local/bin/uv --version | awk '{print $2}')"
+          echo "UV_VERSION=$uv_version" >>"$GITHUB_ENV"
       - name: Cache uv
         uses: actions/cache@v4
         with:
           path: ~/.cache/uv
-          key: uv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
+          key: uv-${{ runner.os }}-${{ env.UV_VERSION || 'latest' }}-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
       - name: Sync deps (frozen)
-        run: uv sync --frozen
+        run: ~/.local/bin/uv sync --frozen
       - name: Smoke run
-        run: uv run python -c "print('uv ok')"
+        run: ~/.local/bin/uv run python -c "print('uv ok')"

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -92,30 +92,46 @@ jobs:
           shfmt -d "${scripts[@]}"
           shellcheck -S style "${scripts[@]}"
 
-      - name: Install uv (only if pyproject exists)
+      - name: Detect Python project
+        id: python-project
+        run: |
+          if [ -f pyproject.toml ]; then
+            echo "present=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "present=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Install uv
+        if: steps.python-project.outputs.present == 'true'
         run: |
           set -euo pipefail
-          if [ ! -f pyproject.toml ]; then
-            echo "No pyproject.toml – skipping uv installation."
-            exit 0
-          fi
           curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.local/bin" >> '$GITHUB_PATH'
-          export PATH="$HOME/.local/bin:$PATH"
-          uv --version
+          echo "$HOME/.local/bin" >>"$GITHUB_PATH"
+          uv_version="$($HOME/.local/bin/uv --version | awk '{print $2}')"
+          echo "UV_VERSION=$uv_version" >>"$GITHUB_ENV"
+
+      - name: Cache uv
+        if: steps.python-project.outputs.present == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ env.UV_VERSION || 'latest' }}-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
+
+      - name: Sync deps (uv)
+        if: steps.python-project.outputs.present == 'true'
+        run: |
+          set -euo pipefail
+          ~/.local/bin/uv sync --frozen
 
       - name: uv contracts (only if pyproject exists)
+        if: steps.python-project.outputs.present == 'true'
         run: |
           set -euo pipefail
-          if [ -f pyproject.toml ]; then
-            if [ -f uv.lock ]; then
-              echo "OK: uv.lock present"
-            else
-              echo "::error::uv.lock missing (pyproject.toml present)"
-              exit 1
-            fi
+          if [ -f uv.lock ]; then
+            echo "OK: uv.lock present"
           else
-            echo "No pyproject.toml – skipping uv.lock check."
+            echo "::error::uv.lock missing (pyproject.toml present)"
+            exit 1
           fi
 
       - name: Rust manifest check


### PR DESCRIPTION
## Summary
- ensure the guard workflow only installs and caches uv when a Python project is present
- add frozen uv sync (with cache keyed by uv.lock) to wgx-guard to enforce the documented contract
- capture the uv version in shell-docs and key the cache accordingly while running sync and smoke commands via the installed binary

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e5d3e02b64832c820550af87e805b6