### PR TITLE
Clarify MIT license scope

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT License
+MIT License (intended for internal use; repository is publicly visible)
 
 Copyright (c) 2025 weltweberei.org
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # wgx – Weltgewebe CLI
 
-Eigenständiges CLI für Git-/Repo-Workflows (Termux, WSL, Linux, macOS). Lizenz: MIT (projektintern).
+Eigenständiges CLI für Git-/Repo-Workflows (Termux, WSL, Linux, macOS). License: MIT; intended for internal use but repository is publicly visible.
 
 ## Schnellstart
 


### PR DESCRIPTION
## Summary
- clarify that the MIT license is intended for internal use while the repository remains publicly visible
- update the README to repeat the clarified licensing note

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5d4221f08832c83612243d510e1c4