### PR TITLE
Add test to ensure CLI entrypoint stays executable

### DIFF
--- a/tests/cli_permissions.bats
+++ b/tests/cli_permissions.bats
@@ -1,0 +1,12 @@
+#!/usr/bin/env bats
+
+setup() {
+  export WGX_DIR="$(pwd)"
+  export PATH="$WGX_DIR/cli:$PATH"
+}
+
+@test "CLI entrypoint has executable bit set" {
+  run git ls-files -s cli/wgx
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == 100755* ]]
+}


### PR DESCRIPTION
## Summary
- add a Bats test that verifies the CLI entrypoint remains tracked as executable

## Testing
- not run (bats not installed in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5d4330bd0832c86292ecfb8e6c898