### PR TITLE
Add Bats guard for shell shebangs and CI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ wgx --list 2>/dev/null || wgx commands 2>/dev/null || ls -1 cmd/
 ## Entwicklungs-Schnellstart
 
 - In VS Code öffnen → „Reopen in Container“
-- CI lokal ausführen:
+- CI lokal ausführen (gespiegelt durch GitHub Actions, via `tests/shell_ci.bats` abgesichert):
 
   ```bash
   bash -n $(git ls-files '*.sh' '*.bash')

--- a/tests/shell_ci.bats
+++ b/tests/shell_ci.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+setup() {
+  load 'test_helper/bats-support/load'
+  load 'test_helper/bats-assert/load'
+  REPO_ROOT="$(pwd)"
+}
+
+@test "tracked shell scripts declare a shebang" {
+  local script="$BATS_TEST_TMPDIR/check-shebang.sh"
+  cat <<'SCRIPT' >"$script"
+#!/usr/bin/env bash
+set -euo pipefail
+
+mapfile -t files < <(git ls-files '*.sh' '*.bash' 'wgx' 'cli/wgx')
+missing=()
+for file in "${files[@]}"; do
+  [[ -f "$file" ]] || continue
+  first_line="$(head -n 1 "$file" 2>/dev/null || true)"
+  if [[ ${first_line} != '#!'* ]]; then
+    missing+=("$file")
+  fi
+done
+
+if (( ${#missing[@]} > 0 )); then
+  {
+    echo "Missing shebang in shell scripts:"
+    printf '  %s\n' "${missing[@]}"
+  } >&2
+  exit 1
+fi
+SCRIPT
+  chmod +x "$script"
+
+  run "$script"
+  assert_success
+  assert_output ""
+}
+
+@test "README shell CI commands stay aligned with GitHub Actions" {
+  local -a readme_patterns=(
+    "bash -n \$(git ls-files '*.sh' '*.bash')"
+    "shfmt -d \$(git ls-files '*.sh' '*.bash')"
+    "shellcheck -S style \$(git ls-files '*.sh' '*.bash')"
+    "bats -r tests"
+  )
+
+  for pattern in "${readme_patterns[@]}"; do
+    run grep -F "$pattern" "$REPO_ROOT/README.md"
+    assert_success
+  done
+
+  local -a workflow_patterns=(
+    "bash -n"
+    "shfmt -d"
+    "shellcheck -S style"
+    "bats-core/bats-action"
+  )
+
+  for pattern in "${workflow_patterns[@]}"; do
+    run grep -F "$pattern" "$REPO_ROOT/.github/workflows/ci.yml"
+    assert_success
+  done
+}


### PR DESCRIPTION
## Summary
- add a dedicated Bats suite that asserts every tracked shell script has a shebang and that our README/CI snippets stay aligned
- document in the developer quickstart that the local CI commands are guarded by the new Bats test

## Testing
- `bats tests/shell_ci.bats` *(fails locally because `bats` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5d4139d0c832c89c7d53515baf8e8