### PR TITLE
Clarify MIT license usage context

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT License (intended for internal use; repository is publicly visible)
+MIT License
 
 Copyright (c) 2025 weltweberei.org
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@
 
 Eigenständiges CLI für Git-/Repo-Workflows (Termux, WSL, Linux, macOS). License: MIT; intended for internal use but repository is publicly visible.
 
+## Lizenz & Nutzung
+
+Dieses Repository steht unter der **MIT-Lizenz** (siehe `./LICENSE`).
+Die Lizenzdatei bleibt **unverändert**, damit gängige Tools die Lizenz korrekt erkennen.
+
+**Beabsichtigte Nutzung:** WGX ist primär für den internen Einsatz innerhalb der
+heimgewebe-Ökosphäre gedacht, das Repository ist jedoch öffentlich sichtbar.
+Diese Klarstellung ändert **nicht** die Lizenzrechte, sondern dient nur der
+Transparenz bezüglich Support-Erwartungen und Projektfokus.
+
+**Hinweis für Beiträge/Dateiköpfe:** In neuen Dateien bitte nach Möglichkeit den
+SPDX-Kurzidentifier verwenden, z. B.:
+
+```
+# SPDX-License-Identifier: MIT
+```
+
 ## Schnellstart
 
 > 📘 **Language policy:** New contributions should use English for user-facing text.


### PR DESCRIPTION
## Summary
- restore the canonical MIT license header so automated scanners can detect it
- document the intended internal focus and SPDX guidance in the README without changing license terms

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5d865fbe8832ca702470fc1abb373