### PR TITLE
Ensure bash installation in wgx-guard workflow

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -34,9 +34,18 @@ jobs:
       - name: Ensure bash is available
         shell: sh
         run: |
+          set -euo pipefail
           if ! command -v bash >/dev/null 2>&1; then
-            echo "::error::bash not found in PATH. Use a runner or container image that already includes bash."
-            exit 1
+            echo "::notice::bash not found – attempting installation"
+            if command -v apk >/dev/null 2>&1; then
+              apk --no-cache add bash
+            elif command -v apt-get >/dev/null 2>&1; then
+              sudo apt-get update
+              sudo apt-get install -y bash
+            else
+              echo "::error::Unable to install bash automatically. Ensure the runner image includes bash."
+              exit 1
+            fi
           fi
           bash --version
 


### PR DESCRIPTION
## Summary
- attempt to install bash automatically when it is missing in the wgx-guard workflow
- keep a useful error message when bash still cannot be installed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5dec1ccd0832c97d0c73505003740