### PR TITLE
security: replace unsafe ast.literal_eval with safe JSON parsing

### DIFF
--- a/modules/profile_parser.py
+++ b/modules/profile_parser.py
@@ -62,13 +62,16 @@ def _parse_scalar(value: str) -> Any:
     # Try numeric types
     if text[0:1] in "0123456789+-" or text.startswith("."):
         try:
-            # Handle hex, octal, binary (0x, 0o, 0b)
-            if len(text) > 2 and text[0] == "0" and text[1].lower() in "xob":
+            # Handle hex, octal, binary (0x, 0o, 0b) with optional sign
+            u_text = text[1:] if text[0] in "+-" else text
+            if len(u_text) > 2 and u_text[0] == "0" and u_text[1].lower() in "xob":
                 return int(text, 0)
+
             # Standard integer or float
-            # Note: leading zeros (e.g. 0123) are treated as strings to match ast.literal_eval behavior in Py3
-            if text.startswith("0") and len(text) > 1 and text[1].isdigit() and "." not in text and "e" not in text.lower():
-                pass # fall through to string
+            # Note: leading zeros (e.g. 0123) are treated as strings to match ast.literal_eval behavior in Py3.
+            # This also applies to signed forms like +0123 or -0123.
+            if u_text.startswith("0") and len(u_text) > 1 and u_text[1].isdigit() and "." not in u_text and "e" not in u_text.lower():
+                pass  # fall through to string
             elif "." in text or "e" in text.lower():
                 return float(text)
             else:

--- a/modules/profile_parser.py
+++ b/modules/profile_parser.py
@@ -34,6 +34,20 @@ RE_STRIP_COMMENT_TOKENS = re.compile(r"""
 # --- YAML Parser (Minimal Subset) ---
 
 def _parse_scalar(value: str) -> Any:
+    """
+    Parses a scalar value from a YAML line.
+
+    Implements a minimal set of YAML-like scalar parsing:
+    - Booleans (true, false, yes, no, on, off)
+    - Nulls (null, none, ~)
+    - Numbers (integers, floats, hex, octal, binary)
+    - Quoted strings (single-quoted with '' escape, double-quoted via JSON)
+    - JSON collections (lists and dicts starting with [ or {)
+
+    NOTE: This explicitly replaces the unsafe 'ast.literal_eval' with a robust
+    JSON-only fallback. Python-specific literals like single-quoted dicts ({'a': 1}),
+    tuples, or sets are intentionally no longer parsed and will return as strings.
+    """
     text = value.strip()
     if text == "":
         return ""
@@ -74,14 +88,14 @@ def _parse_scalar(value: str) -> Any:
         if text.startswith('"') and text.endswith('"'):
             try:
                 return json.loads(text)
-            except (json.JSONDecodeError, TypeError):
+            except (ValueError, TypeError, RecursionError):
                 pass
 
     # Collections (JSON fallback for lists/dicts)
     if text.startswith(("[", "{")):
         try:
             return json.loads(text)
-        except (json.JSONDecodeError, TypeError):
+        except (ValueError, TypeError, RecursionError):
             pass
 
     return text

--- a/modules/profile_parser.py
+++ b/modules/profile_parser.py
@@ -6,7 +6,6 @@ This script parses .wgx/profile.yml files when PyYAML is not available.
 It implements a minimal subset of block-style YAML necessary for wgx profiles.
 It does NOT support the full YAML specification (e.g. flow style, complex keys, anchors).
 """
-import ast
 import json
 import os
 import re
@@ -45,10 +44,47 @@ def _parse_scalar(value: str) -> Any:
         return False
     if lowered in {"null", "none", "~"}:
         return None
-    try:
-        return ast.literal_eval(text)
-    except Exception:
-        return text
+
+    # Try numeric types
+    if text[0:1] in "0123456789+-" or text.startswith("."):
+        try:
+            # Handle hex, octal, binary (0x, 0o, 0b)
+            if len(text) > 2 and text[0] == "0" and text[1].lower() in "xob":
+                return int(text, 0)
+            # Standard integer or float
+            # Note: leading zeros (e.g. 0123) are treated as strings to match ast.literal_eval behavior in Py3
+            if text.startswith("0") and len(text) > 1 and text[1].isdigit() and "." not in text and "e" not in text.lower():
+                pass # fall through to string
+            elif "." in text or "e" in text.lower():
+                return float(text)
+            else:
+                try:
+                    return int(text)
+                except ValueError:
+                    # Fallback for things like '123-abc'
+                    pass
+        except (ValueError, TypeError):
+            pass
+
+    # Handle quoted strings
+    if len(text) >= 2:
+        if text.startswith("'") and text.endswith("'"):
+            # YAML single quotes: '' is an escaped '
+            return text[1:-1].replace("''", "'")
+        if text.startswith('"') and text.endswith('"'):
+            try:
+                return json.loads(text)
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+    # Collections (JSON fallback for lists/dicts)
+    if text.startswith(("[", "{")):
+        try:
+            return json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    return text
 
 def _convert_frame(frame: Dict[str, Any], kind: str) -> None:
     if frame["type"] == kind:

--- a/tests/test_profile_parser.py
+++ b/tests/test_profile_parser.py
@@ -167,9 +167,24 @@ class TestProfileParser(unittest.TestCase):
 
         # Numbers
         self.assertEqual(profile_parser._parse_scalar("123"), 123)
+        self.assertEqual(profile_parser._parse_scalar("+123"), 123)
         self.assertEqual(profile_parser._parse_scalar("-456"), -456)
         self.assertEqual(profile_parser._parse_scalar("3.14"), 3.14)
         self.assertEqual(profile_parser._parse_scalar("1e-10"), 1e-10)
+
+        # Non-decimal numerics (hex, oct, bin)
+        self.assertEqual(profile_parser._parse_scalar("0x10"), 16)
+        self.assertEqual(profile_parser._parse_scalar("-0x10"), -16)
+        self.assertEqual(profile_parser._parse_scalar("+0x10"), 16)
+        self.assertEqual(profile_parser._parse_scalar("0b101"), 5)
+        self.assertEqual(profile_parser._parse_scalar("-0b101"), -5)
+        self.assertEqual(profile_parser._parse_scalar("0o7"), 7)
+        self.assertEqual(profile_parser._parse_scalar("-0o7"), -7)
+
+        # Leading zeros (should be treated as strings)
+        self.assertEqual(profile_parser._parse_scalar("0123"), "0123")
+        self.assertEqual(profile_parser._parse_scalar("+0123"), "+0123")
+        self.assertEqual(profile_parser._parse_scalar("-0123"), "-0123")
 
         # Quoted strings
         self.assertEqual(profile_parser._parse_scalar("'hello'"), "hello")

--- a/tests/test_profile_parser.py
+++ b/tests/test_profile_parser.py
@@ -193,28 +193,26 @@ class TestProfileParser(unittest.TestCase):
 
     def test_parse_scalar_dos_resilience(self):
         """Verify that _parse_scalar is resilient against deeply nested inputs (no RecursionError)."""
-        # Create a deeply nested JSON-like structure
-        depth = 1000
+        # Create a deeply nested JSON-like structure.
+        # Large depth should trigger RecursionError in vulnerable parsers.
+        depth = 10000
         malicious_input = "[" * depth + "1" + "]" * depth
 
-        # json.loads usually has a recursion limit or handles nesting safely.
-        # ast.literal_eval is known to crash with RecursionError on such inputs in many Python versions.
+        # json.loads may have a recursion limit.
+        # ast.literal_eval is known to crash with RecursionError on such inputs.
         try:
             result = profile_parser._parse_scalar(malicious_input)
-            # If it didn't crash, we're good.
-            # Depending on the JSON parser, it might parse it or return it as a string if it fails.
+            # If it didn't crash, it should either have parsed it or returned it as a string.
             if isinstance(result, list):
-                # Verify depth if parsed
+                # Verify depth if it actually parsed it (unlikely at 10k depth for most systems)
                 curr = result
                 for _ in range(depth - 1):
                     curr = curr[0]
                 self.assertEqual(curr, [1])
+            else:
+                self.assertEqual(result, malicious_input)
         except RecursionError:
             self.fail("_parse_scalar raised RecursionError on deeply nested input")
-        except Exception as e:
-            # Other exceptions like ValueError (from json.loads) are acceptable,
-            # as long as they don't crash the process with a stack overflow.
-            pass
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_profile_parser.py
+++ b/tests/test_profile_parser.py
@@ -135,7 +135,7 @@ class TestProfileParser(unittest.TestCase):
                     self.assertIn("task name collision", stderr)
 
     def test_parse_scalar(self):
-        """Test _parse_scalar for common scalar values and literal-eval fallbacks."""
+        """Test _parse_scalar for common scalar values and JSON fallbacks."""
         # Empty/Whitespace
         self.assertEqual(profile_parser._parse_scalar(""), "")
         self.assertEqual(profile_parser._parse_scalar("  "), "")
@@ -171,21 +171,50 @@ class TestProfileParser(unittest.TestCase):
         self.assertEqual(profile_parser._parse_scalar("3.14"), 3.14)
         self.assertEqual(profile_parser._parse_scalar("1e-10"), 1e-10)
 
-        # Quoted strings (handled by ast.literal_eval)
+        # Quoted strings
         self.assertEqual(profile_parser._parse_scalar("'hello'"), "hello")
         self.assertEqual(profile_parser._parse_scalar('"world"'), "world")
+        self.assertEqual(profile_parser._parse_scalar("'it''s'"), "it's")
 
         # Literal strings
         self.assertEqual(profile_parser._parse_scalar("hello"), "hello")
         self.assertEqual(profile_parser._parse_scalar("123-abc"), "123-abc")
 
-        # Python-literal fallbacks (via ast.literal_eval)
+        # JSON fallbacks
         # Note: These are NOT standard YAML scalars but supported via fallback.
         self.assertEqual(profile_parser._parse_scalar("[1, 2]"), [1, 2])
-        self.assertEqual(profile_parser._parse_scalar("{'a': 1}"), {'a': 1})
+        self.assertEqual(profile_parser._parse_scalar('{"a": 1}'), {"a": 1})
+
+        # Single quoted dict (should fall back to string because it's not valid JSON)
+        self.assertEqual(profile_parser._parse_scalar("{'a': 1}"), "{'a': 1}")
 
         # Non-Python-literal flow mapping (should fall back to string)
         self.assertEqual(profile_parser._parse_scalar("{a: 1}"), "{a: 1}")
+
+    def test_parse_scalar_dos_resilience(self):
+        """Verify that _parse_scalar is resilient against deeply nested inputs (no RecursionError)."""
+        # Create a deeply nested JSON-like structure
+        depth = 1000
+        malicious_input = "[" * depth + "1" + "]" * depth
+
+        # json.loads usually has a recursion limit or handles nesting safely.
+        # ast.literal_eval is known to crash with RecursionError on such inputs in many Python versions.
+        try:
+            result = profile_parser._parse_scalar(malicious_input)
+            # If it didn't crash, we're good.
+            # Depending on the JSON parser, it might parse it or return it as a string if it fails.
+            if isinstance(result, list):
+                # Verify depth if parsed
+                curr = result
+                for _ in range(depth - 1):
+                    curr = curr[0]
+                self.assertEqual(curr, [1])
+        except RecursionError:
+            self.fail("_parse_scalar raised RecursionError on deeply nested input")
+        except Exception as e:
+            # Other exceptions like ValueError (from json.loads) are acceptable,
+            # as long as they don't crash the process with a stack overflow.
+            pass
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Replaced `ast.literal_eval` in `modules/profile_parser.py` with safe `json.loads` and explicit numeric parsing. This mitigates Potential DoS attacks via deeply nested inputs. Updated tests to reflect the change and added a resilience test case.