### PR TITLE
fix(ci): pin reusable WGX guard actions

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -15,17 +15,17 @@ jobs:
 
     steps:
       - name: Checkout target repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Checkout pinned WGX CLI
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           repository: heimgewebe/wgx
           ref: 5a02f83378add575b6230ee3f13a1a26158d730b
           path: .wgx-cli
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.x'
 

--- a/scripts/check_wgx_guard_action_pins.py
+++ b/scripts/check_wgx_guard_action_pins.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Require immutable external action refs in the reusable WGX guard workflow."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*([^\s#]+)")
+FULL_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+DEFAULT_WORKFLOW = Path(".github/workflows/wgx-guard.yml")
+
+
+def check_workflow(path: Path) -> list[str]:
+    findings: list[str] = []
+    external_count = 0
+
+    if not path.is_file():
+        return [f"workflow not found: {path}"]
+
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        match = USES_RE.match(line)
+        if match is None:
+            continue
+        value = match.group(1)
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"\"", "'"}:
+            value = value[1:-1]
+        if value.startswith("./"):
+            continue
+        external_count += 1
+        if "@" not in value:
+            findings.append(f"{path}:{line_number}: external uses ref has no @ revision: {value}")
+            continue
+        target, revision = value.rsplit("@", 1)
+        if not FULL_COMMIT_RE.fullmatch(revision):
+            findings.append(
+                f"{path}:{line_number}: {target}@{revision} is not pinned to a full lowercase commit SHA"
+            )
+
+    if external_count == 0:
+        findings.append(f"{path}: no external uses references found")
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) > 1:
+        print("usage: check_wgx_guard_action_pins.py [workflow]", file=sys.stderr)
+        return 2
+    path = Path(args[0]) if args else DEFAULT_WORKFLOW
+    findings = check_workflow(path)
+    if findings:
+        for finding in findings:
+            print(f"FAIL: {finding}", file=sys.stderr)
+        return 1
+    print(f"PASS: all external uses references in {path} are full commit pins")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/wgx_guard_action_pins.bats
+++ b/tests/wgx_guard_action_pins.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  WORKDIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$WORKDIR"
+}
+
+@test "repository WGX guard pins every external action to a full commit" {
+  run python3 "$WGX_PROJECT_ROOT/scripts/check_wgx_guard_action_pins.py" \
+    "$WGX_PROJECT_ROOT/.github/workflows/wgx-guard.yml"
+  assert_success
+  assert_output --partial "PASS: all external uses references"
+}
+
+@test "WGX guard pin checker rejects mutable major tags" {
+  cat >"$WORKDIR/workflow.yml" <<'YAML'
+jobs:
+  guard:
+    steps:
+      - uses: actions/checkout@v4
+YAML
+
+  run python3 "$WGX_PROJECT_ROOT/scripts/check_wgx_guard_action_pins.py" \
+    "$WORKDIR/workflow.yml"
+  assert_failure
+  assert_output --partial "actions/checkout@v4 is not pinned"
+}
+
+@test "WGX guard pin checker rejects abbreviated SHAs" {
+  cat >"$WORKDIR/workflow.yml" <<'YAML'
+jobs:
+  guard:
+    steps:
+      - uses: actions/setup-python@a26af69
+YAML
+
+  run python3 "$WGX_PROJECT_ROOT/scripts/check_wgx_guard_action_pins.py" \
+    "$WORKDIR/workflow.yml"
+  assert_failure
+  assert_output --partial "actions/setup-python@a26af69 is not pinned"
+}
+
+@test "WGX guard pin checker permits repository-local actions" {
+  cat >"$WORKDIR/workflow.yml" <<'YAML'
+jobs:
+  guard:
+    steps:
+      - uses: "./local-action"
+      - uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
+YAML
+
+  run python3 "$WGX_PROJECT_ROOT/scripts/check_wgx_guard_action_pins.py" \
+    "$WORKDIR/workflow.yml"
+  assert_success
+}


### PR DESCRIPTION
## Zweck

Schließt den WGX-Anteil von Lenskit-Task `TASK-LENSKIT-AUDIT-CI-SUPPLY-CHAIN-UPSTREAM-TRANSITIVE-001`.

## Änderungen

- pinnt beide `actions/checkout@v4`-Aufrufe im wiederverwendbaren `wgx-guard.yml` auf Commit `34e114876b0b11c390a56381ad16ebd13914f8d5`;
- pinnt `actions/setup-python@v5` auf `a26af69be951a213d495a4c3e4e4022e16d87065`;
- ergänzt einen auf diesen wiederverwendbaren Guard begrenzten Ratchet für alle externen `uses:`-Referenzen;
- ergänzt Fälschungstests gegen Major-Tags und Kurz-SHAs.

## Lokale Validierung

- 4 gezielte Bats-Tests bestanden;
- 66 Python-Tests bestanden;
- Workflow-YAML validiert;
- Pin-Checker grün.

## Abgrenzung

Andere bewegliche Action-Tags im WGX-Repository sind nicht Teil dieses begrenzten Upstream-Slices. Der Lenskit-Caller wird erst nach gemergten WGX- und metarepo-Upstream-Änderungen auf neue Commit-SHAs gesetzt.