### PR TITLE
fix(ci): restore reusable pinned WGX smoke

### DIFF
--- a/.github/workflows/wgx-smoke.yml
+++ b/.github/workflows/wgx-smoke.yml
@@ -1,17 +1,112 @@
 ---
 name: wgx-smoke
 
-permissions:
-  contents: read
 "on":
+  workflow_call:
   workflow_dispatch:
   push:
+    branches: [main]
     paths:
       - ".wgx/**"
-      - "docs/wgx-konzept.md"
+      - ".github/workflows/wgx-smoke.yml"
+      - "modules/profile.bash"
+      - "modules/profile_parser.py"
+      - "tests/test_profile_parser.py"
+      - "tests/wgx_guard_action_pins.bats"
+      - "scripts/check_wgx_guard_action_pins.py"
+      - "scripts/check_wgx_smoke_contract.py"
+      - "scripts/validate_workflow.py"
+  pull_request:
+    paths:
+      - ".wgx/**"
+      - ".github/workflows/wgx-smoke.yml"
+      - "modules/profile.bash"
+      - "modules/profile_parser.py"
+      - "tests/test_profile_parser.py"
+      - "tests/wgx_guard_action_pins.bats"
+      - "scripts/check_wgx_guard_action_pins.py"
+      - "scripts/check_wgx_smoke_contract.py"
+      - "scripts/validate_workflow.py"
+
+permissions:
+  contents: read
 
 jobs:
   smoke:
-    # auch hier: statt eigener CI-Logik nur noch Forwarder auf das
-    # kanonische wgx-Workflow-Repo.
-    uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@main
+    name: Smoke Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout target repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+
+      - name: Checkout pinned WGX CLI
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          repository: heimgewebe/wgx
+          ref: 0c19e27f8135e0121045c24466848e312c996a85
+          path: .wgx-cli
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install hash-bound profile parser dependency
+        run: |
+          set -euo pipefail
+          requirements_file="${RUNNER_TEMP}/wgx-smoke-requirements.txt"
+          cat >"$requirements_file" <<'EOF'
+          PyYAML==6.0.3 \
+            --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc
+          EOF
+          python3 -m pip install \
+            --disable-pip-version-check \
+            --only-binary=:all: \
+            --require-hashes \
+            --requirement "$requirements_file"
+
+      - name: Prepare target-provided tools
+        run: |
+          set -euo pipefail
+          if [[ -x scripts/tools/yq-pin.sh ]]; then
+            ALLOW_NET=1 scripts/tools/yq-pin.sh ensure
+            echo "${PWD}/tools/bin" >> "$GITHUB_PATH"
+          fi
+
+      - name: Make pinned WGX available in PATH
+        run: |
+          set -euo pipefail
+          chmod +x .wgx-cli/wgx
+          echo "${PWD}/.wgx-cli" >> "$GITHUB_PATH"
+
+      - name: Verify WGX installation
+        run: |
+          set -euo pipefail
+          command -v wgx >/dev/null 2>&1
+          wgx version
+
+      - name: Require and run declared smoke task
+        env:
+          WGX_TARGET_ROOT: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          tasks_json="$(wgx tasks --json)"
+          TASKS_JSON="$tasks_json" python3 - <<'PY'
+          import json
+          import os
+
+          payload = json.loads(os.environ["TASKS_JSON"])
+          names = {
+              item.get("name")
+              for item in payload.get("tasks", [])
+              if isinstance(item, dict)
+          }
+          if "smoke" not in names:
+              raise SystemExit("WGX profile does not declare a smoke task")
+          PY
+          wgx task smoke

--- a/.github/workflows/wgx-smoke.yml
+++ b/.github/workflows/wgx-smoke.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           repository: heimgewebe/wgx
-          ref: 0c19e27f8135e0121045c24466848e312c996a85
+          ref: 4b688c8c06dcb895312fa222f4bf047ccfb6da0c
           path: .wgx-cli
           persist-credentials: false
 

--- a/.wgx/profile.example.yml
+++ b/.wgx/profile.example.yml
@@ -3,6 +3,7 @@ wgx:
   requiredWgx: "^2.0"
   repoKind: "generic"
   tasks:
+    guard: "python3 scripts/check_wgx_guard_action_pins.py && python3 scripts/check_wgx_smoke_contract.py"
     smoke: "python3 scripts/validate_workflow.py .github/workflows/wgx-smoke.yml"
     test: "bats -r tests"
     lint: "FILES=$(git ls-files '*.sh' '*.bash'); shfmt -d $FILES && shellcheck -S style $FILES"

--- a/.wgx/profile.example.yml
+++ b/.wgx/profile.example.yml
@@ -3,5 +3,6 @@ wgx:
   requiredWgx: "^2.0"
   repoKind: "generic"
   tasks:
+    smoke: "python3 scripts/validate_workflow.py .github/workflows/wgx-smoke.yml"
     test: "bats -r tests"
     lint: "FILES=$(git ls-files '*.sh' '*.bash'); shfmt -d $FILES && shellcheck -S style $FILES"

--- a/scripts/check_wgx_guard_action_pins.py
+++ b/scripts/check_wgx_guard_action_pins.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Require immutable external action refs in the reusable WGX guard workflow."""
+"""Require immutable external action refs in reusable WGX workflows."""
 
 from __future__ import annotations
 
@@ -9,7 +9,10 @@ from pathlib import Path
 
 USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*([^\s#]+)")
 FULL_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
-DEFAULT_WORKFLOW = Path(".github/workflows/wgx-guard.yml")
+DEFAULT_WORKFLOWS = (
+    Path(".github/workflows/wgx-guard.yml"),
+    Path(".github/workflows/wgx-smoke.yml"),
+)
 
 
 def check_workflow(path: Path) -> list[str]:
@@ -45,16 +48,14 @@ def check_workflow(path: Path) -> list[str]:
 
 def main(argv: list[str] | None = None) -> int:
     args = sys.argv[1:] if argv is None else argv
-    if len(args) > 1:
-        print("usage: check_wgx_guard_action_pins.py [workflow]", file=sys.stderr)
-        return 2
-    path = Path(args[0]) if args else DEFAULT_WORKFLOW
-    findings = check_workflow(path)
+    paths = tuple(Path(arg) for arg in args) if args else DEFAULT_WORKFLOWS
+    findings = [finding for path in paths for finding in check_workflow(path)]
     if findings:
         for finding in findings:
             print(f"FAIL: {finding}", file=sys.stderr)
         return 1
-    print(f"PASS: all external uses references in {path} are full commit pins")
+    joined = ", ".join(str(path) for path in paths)
+    print(f"PASS: all external uses references in {joined} are full commit pins")
     return 0
 
 

--- a/scripts/check_wgx_smoke_contract.py
+++ b/scripts/check_wgx_smoke_contract.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 DEFAULT_WORKFLOW = Path(".github/workflows/wgx-smoke.yml")
-PINNED_CLI_COMMIT = "0c19e27f8135e0121045c24466848e312c996a85"
+PINNED_CLI_COMMIT = "4b688c8c06dcb895312fa222f4bf047ccfb6da0c"
 PY_YAML_WHEEL_SHA256 = "ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc"
 
 

--- a/scripts/check_wgx_smoke_contract.py
+++ b/scripts/check_wgx_smoke_contract.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Validate the reusable, immutable WGX smoke workflow contract."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+DEFAULT_WORKFLOW = Path(".github/workflows/wgx-smoke.yml")
+PINNED_CLI_COMMIT = "0c19e27f8135e0121045c24466848e312c996a85"
+PY_YAML_WHEEL_SHA256 = "ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc"
+
+
+def check_contract(path: Path) -> list[str]:
+    if not path.is_file():
+        return [f"workflow not found: {path}"]
+
+    text = path.read_text(encoding="utf-8")
+    findings: list[str] = []
+    required_fragments = {
+        "workflow_call trigger": "  workflow_call:",
+        "pinned WGX CLI checkout": f"          ref: {PINNED_CLI_COMMIT}",
+        "fixed Python runtime": '          python-version: "3.12"',
+        "hash-only dependency install": "--require-hashes",
+        "binary-only dependency install": "--only-binary=:all:",
+        "pinned PyYAML version": "PyYAML==6.0.3",
+        "pinned PyYAML wheel hash": f"            --hash=sha256:{PY_YAML_WHEEL_SHA256}",
+        "declared smoke-task failure": "WGX profile does not declare a smoke task",
+        "smoke task execution": "          wgx task smoke",
+    }
+    for label, fragment in required_fragments.items():
+        if fragment not in text:
+            findings.append(f"{path}: missing {label}")
+
+    if "ref: main" in text:
+        findings.append(f"{path}: WGX CLI checkout must not use ref: main")
+    if "wgx-smoke.yml@main" in text:
+        findings.append(f"{path}: smoke workflow must not recursively call @main")
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) > 1:
+        print("usage: check_wgx_smoke_contract.py [workflow]", file=sys.stderr)
+        return 2
+    path = Path(args[0]) if args else DEFAULT_WORKFLOW
+    findings = check_contract(path)
+    if findings:
+        for finding in findings:
+            print(f"FAIL: {finding}", file=sys.stderr)
+        return 1
+    print(f"PASS: {path} is reusable and bound to the pinned WGX CLI")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/wgx_guard_action_pins.bats
+++ b/tests/wgx_guard_action_pins.bats
@@ -31,11 +31,18 @@ teardown() {
   assert_output --partial "is reusable and bound"
 }
 
-@test "WGX example profile declares an executable smoke task" {
+@test "WGX example profile declares executable guard and smoke tasks" {
   run env WGX_TARGET_ROOT="$WGX_PROJECT_ROOT" \
     "$WGX_PROJECT_ROOT/wgx" tasks --json
   assert_success
+  assert_output --partial '"name":"guard"'
   assert_output --partial '"name":"smoke"'
+
+  run env WGX_TARGET_ROOT="$WGX_PROJECT_ROOT" \
+    "$WGX_PROJECT_ROOT/wgx" task guard
+  assert_success
+  assert_output --partial "all external uses references"
+  assert_output --partial "is reusable and bound"
 
   run env WGX_TARGET_ROOT="$WGX_PROJECT_ROOT" \
     "$WGX_PROJECT_ROOT/wgx" task smoke

--- a/tests/wgx_guard_action_pins.bats
+++ b/tests/wgx_guard_action_pins.bats
@@ -44,10 +44,11 @@ teardown() {
   assert_output --partial "all external uses references"
   assert_output --partial "is reusable and bound"
 
-  run env WGX_TARGET_ROOT="$WGX_PROJECT_ROOT" \
+  run env WGX_TARGET_ROOT="$WGX_PROJECT_ROOT" DRYRUN=1 \
     "$WGX_PROJECT_ROOT/wgx" task smoke
   assert_success
-  assert_output --partial "OK   .github/workflows/wgx-smoke.yml"
+  assert_output --partial "[DRY-RUN]"
+  assert_output --partial "scripts/validate_workflow.py .github/workflows/wgx-smoke.yml"
 }
 
 @test "WGX guard pin checker rejects mutable major tags" {

--- a/tests/wgx_guard_action_pins.bats
+++ b/tests/wgx_guard_action_pins.bats
@@ -17,6 +17,32 @@ teardown() {
   assert_output --partial "PASS: all external uses references"
 }
 
+@test "repository WGX smoke pins every external action to a full commit" {
+  run python3 "$WGX_PROJECT_ROOT/scripts/check_wgx_guard_action_pins.py" \
+    "$WGX_PROJECT_ROOT/.github/workflows/wgx-smoke.yml"
+  assert_success
+  assert_output --partial "PASS: all external uses references"
+}
+
+@test "repository WGX smoke is reusable and bound to a fixed CLI commit" {
+  run python3 "$WGX_PROJECT_ROOT/scripts/check_wgx_smoke_contract.py" \
+    "$WGX_PROJECT_ROOT/.github/workflows/wgx-smoke.yml"
+  assert_success
+  assert_output --partial "is reusable and bound"
+}
+
+@test "WGX example profile declares an executable smoke task" {
+  run env WGX_TARGET_ROOT="$WGX_PROJECT_ROOT" \
+    "$WGX_PROJECT_ROOT/wgx" tasks --json
+  assert_success
+  assert_output --partial '"name":"smoke"'
+
+  run env WGX_TARGET_ROOT="$WGX_PROJECT_ROOT" \
+    "$WGX_PROJECT_ROOT/wgx" task smoke
+  assert_success
+  assert_output --partial "OK   .github/workflows/wgx-smoke.yml"
+}
+
 @test "WGX guard pin checker rejects mutable major tags" {
   cat >"$WORKDIR/workflow.yml" <<'YAML'
 jobs:
@@ -57,4 +83,47 @@ YAML
   run python3 "$WGX_PROJECT_ROOT/scripts/check_wgx_guard_action_pins.py" \
     "$WORKDIR/workflow.yml"
   assert_success
+}
+
+@test "WGX smoke contract rejects an unhashed PyYAML install" {
+  cp "$WGX_PROJECT_ROOT/.github/workflows/wgx-smoke.yml" "$WORKDIR/smoke-unhashed.yml"
+  python3 - "$WORKDIR/smoke-unhashed.yml" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+text = text.replace("--require-hashes", "--no-cache-dir")
+text = text.replace(
+    "--hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc",
+    "--hash=sha256:" + "0" * 64,
+)
+path.write_text(text, encoding="utf-8")
+PY
+
+  run python3 "$WGX_PROJECT_ROOT/scripts/check_wgx_smoke_contract.py" \
+    "$WORKDIR/smoke-unhashed.yml"
+  assert_failure
+  assert_output --partial "missing hash-only dependency install"
+  assert_output --partial "missing pinned PyYAML wheel hash"
+}
+
+@test "WGX smoke contract rejects a mutable CLI ref" {
+  cat >"$WORKDIR/smoke.yml" <<'YAML'
+"on":
+  workflow_call:
+jobs:
+  smoke:
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: main
+      - run: echo "WGX profile does not declare a smoke task"
+      - run: wgx task smoke
+YAML
+
+  run python3 "$WGX_PROJECT_ROOT/scripts/check_wgx_smoke_contract.py" \
+    "$WORKDIR/smoke.yml"
+  assert_failure
+  assert_output --partial "must not use ref: main"
 }


### PR DESCRIPTION
## Zweck

Stellt den wiederverwendbaren WGX-Smoke-Vertrag wieder her. Der Parser-/`eval`-Prerequisite wurde zuvor getrennt über PR #638 gemergt; dieser PR enthält nun nur noch den Smoke-Vertrag und pinnt die WGX-CLI auf den dauerhaft in `main` erreichbaren Parser-Head.

## Änderungen

- veröffentlicht `wgx-smoke.yml` über `workflow_call`;
- pinnt Checkout, Python-Setup und WGX-CLI auf vollständige Commit-SHAs;
- pinnt die WGX-CLI auf `4b688c8c06dcb895312fa222f4bf047ccfb6da0c` aus dem gemergten Parser-PR #638;
- bindet Python an 3.12 und PyYAML 6.0.3 an das manylinux-x86_64-Wheel mit SHA-256 `ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc`;
- verlangt im Zielprofil einen echten `smoke`-Task und scheitert bei dessen Fehlen;
- trennt Guard- und Smoke-Tasks im Beispielprofil;
- ergänzt Pin-, Workflow-, Hash- und Fälschungsratchets.

## Gebundene Evidenz

- Base: `5951a0e31471938a28557d50060826a8c4ec9b6f`
- Head: `e1e1bca334267884a97c0135802dd3265862069f`
- Diff SHA-256: `38de76214f77c85a1042f1a8368e22c02466bc6172cebd9af09c81819d9475bc`
- risikogewichteter Selbstreview: **PASS**

## Prerequisite

- Parser-/Security-PR #638: **gemergt**
- Parser-Head `4b688c8c06dcb895312fa222f4bf047ccfb6da0c`: nachweislich Vorfahr von `main`
- Merge-Commit: `5951a0e31471938a28557d50060826a8c4ec9b6f`

## Lokale Validierung

- Smoke-Vertragsvalidator: PASS;
- Action-Pin-Validator: PASS;
- Workflow-Parser: PASS;
- 77 Python-Tests: PASS;
- 9 WGX-Pin-/Smoke-Vertragstests: PASS;
- `bash -n`, `shellcheck`, `shfmt`, `git diff --check`: PASS.

## Werkzeuggrenze

`actionlint` ist auf dem Host nicht installiert. Der repositoryeigene Workflow-Parser ist grün; GitHub-CI ist das verbindliche Gate für Actionlint und den unterstützten Runner.

## Abgrenzung

Keine globale WGX-Paketmodernisierung und keine Änderung fremder Repository-Smoke-Tasks. Die Merge-Reife von metarepo PR #646 wird nicht behauptet; sie muss nach diesem Merge separat gegen den veröffentlichten WGX-Vertrag geprüft werden.
