### PR TITLE
fix(profile): harden multiline parser evaluation

### DIFF
--- a/modules/profile.bash
+++ b/modules/profile.bash
@@ -148,6 +148,44 @@ profile::_normalize_task_name() {
   # which uses re.sub(r'-+', '-', name.replace(' ', '').replace('_', '-').lower())
 }
 
+profile::_ansi_c_word_is_safe() {
+  local value="${1-}"
+  local length=${#value}
+  ((length >= 3)) || return 1
+  [[ ${value:0:2} == \$\' && ${value:length-1:1} == \' ]] || return 1
+
+  local body="${value:2:length-3}"
+  local body_length=${#body}
+  local i=0 ch next hex
+  while ((i < body_length)); do
+    ch="${body:i:1}"
+    [[ $ch != "'" && $ch != $'\n' && $ch != $'\r' && $ch != $'\t' ]] || return 1
+    if [[ $ch != "\\" ]]; then
+      i=$((i + 1))
+      continue
+    fi
+
+    i=$((i + 1))
+    ((i < body_length)) || return 1
+    next="${body:i:1}"
+    case "$next" in
+    "\\" | "'" | n | r | t)
+      i=$((i + 1))
+      ;;
+    x)
+      ((i + 2 < body_length)) || return 1
+      hex="${body:i+1:2}"
+      [[ $hex =~ ^[0-9A-Fa-f]{2}$ ]] || return 1
+      i=$((i + 3))
+      ;;
+    *)
+      return 1
+      ;;
+    esac
+  done
+  return 0
+}
+
 profile::_parser_line_is_safe() {
   local line="${1:-}"
   # strip CR (Windows line endings)
@@ -162,58 +200,31 @@ profile::_parser_line_is_safe() {
     return 1
   fi
 
-  # allow only assignment-like forms:
-  #   VAR=...
-  #   VAR+=...
-  #   VAR+=(...)  (array append)
-  #   VAR_key=...  (flat variable naming)
-  #   declare -g[aA]? VAR=(...)
-  #   declare -g[aA]? VAR=...
-  if [[ $line =~ ^declare[[:space:]]+-g[aA]?[a-zA-Z-]*[[:space:]]+[A-Za-z_][A-Za-z0-9_]*= ]]; then
-    return 0
-  fi
-  if [[ $line =~ ^[A-Za-z_][A-Za-z0-9_]*(\+?=).+ ]]; then
-    # Extract the part before = to check it's a valid variable name
-    # This allows VAR=value and VAR_key=value but not VAR[key]=value
-    local var_part
-    if [[ $line == *"+="* ]]; then
-      var_part="${line%%+=*}"
-    else
-      var_part="${line%%=*}"
-    fi
+  # Accept only the two assignment forms emitted by profile_parser.py.
+  # Capturing the operator next to the variable name avoids mistaking a value
+  # such as "foo+=bar" for an array append.
+  if [[ $line =~ ^([A-Za-z_][A-Za-z0-9_]*)(\+?=)(.+)$ ]]; then
+    local var_part="${BASH_REMATCH[1]}"
+    local operator="${BASH_REMATCH[2]}"
+    local value_part="${BASH_REMATCH[3]}"
     if [[ $var_part =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
-      # Valid flat variable name, now check the value
-      # Extract the value part (everything after = or +=)
-      local value_part
-      if [[ $line == *"+="* ]]; then
-        value_part="${line#*+=}"
-      else
-        value_part="${line#*=}"
-      fi
 
-      # Allow array append syntax: VAR+=(value)
-      if [[ $value_part == \(* && $value_part == *\) ]]; then
-        # Check content inside parentheses
+      # Allow exactly one parser-emitted word inside array append syntax.
+      if [[ $operator == "+=" && $value_part == \(* && $value_part == *\) ]]; then
         local inner="${value_part#\(}"
         inner="${inner%\)}"
-        # Allow if properly quoted or is a simple value (letters, digits, underscores, hyphens)
-        if [[ $inner == \"*\" || $inner == \'*\' || $inner =~ ^[A-Za-z0-9_-]+$ ]]; then
+        if [[ $inner =~ ^[A-Za-z0-9_@%+=:,./-]+$ ]] || profile::_ansi_c_word_is_safe "$inner"; then
           return 0
         fi
-      fi
-
-      # Check if value is quoted. ANSI-C quotes are emitted for multiline
-      # parser values so every assignment remains one physical line.
-      if [[ $value_part == \$\'*\' || $value_part == \"*\" || $value_part == \'*\' ]]; then
-        # Properly quoted value, allow special chars inside quotes
-        return 0
-      fi
-      # If not quoted, apply strict checks
-      # shellcheck disable=SC2016
-      if [[ $value_part == *'$('* || $value_part == *'`'* || $value_part == *';'* || $value_part == *'|'* || $value_part == *'&'* || $value_part == *'<'* || $value_part == *'>'* ]]; then
         return 1
       fi
-      return 0
+
+      # Scalar assignments accept one simple token or one complete ANSI-C word.
+      # Concatenated shell words and expansion syntax are rejected before eval.
+      if [[ $value_part =~ ^[A-Za-z0-9_@%+=:,./-]+$ ]] || profile::_ansi_c_word_is_safe "$value_part"; then
+        return 0
+      fi
+      return 1
     fi
   fi
 

--- a/modules/profile.bash
+++ b/modules/profile.bash
@@ -202,8 +202,9 @@ profile::_parser_line_is_safe() {
         fi
       fi
 
-      # Check if value starts with a quote (single or double)
-      if [[ $value_part == \"*\" || $value_part == \'*\' ]]; then
+      # Check if value is quoted. ANSI-C quotes are emitted for multiline
+      # parser values so every assignment remains one physical line.
+      if [[ $value_part == \$\'*\' || $value_part == \"*\" || $value_part == \'*\' ]]; then
         # Properly quoted value, allow special chars inside quotes
         return 0
       fi

--- a/modules/profile_parser.py
+++ b/modules/profile_parser.py
@@ -342,6 +342,33 @@ def emit(line: str) -> None:
     sys.stdout.write(f"{line}\n")
 
 def shell_quote(value: str) -> str:
+    """Return one Bash-safe token without emitting physical newlines.
+
+    The Bash loader validates and evaluates parser output one line at a time.
+    ``shlex.quote`` preserves literal newlines, which turns one assignment into
+    several physical lines and breaks that contract. Bash ANSI-C quoting keeps
+    control characters escaped on one line and reconstructs them during eval.
+    """
+    if "\x00" in value:
+        raise ValueError("profile values cannot contain NUL bytes")
+    if any(ch in value for ch in "\n\r\t"):
+        escaped = []
+        for ch in value:
+            if ch == "\\":
+                escaped.append("\\\\")
+            elif ch == "'":
+                escaped.append("\\'")
+            elif ch == "\n":
+                escaped.append("\\n")
+            elif ch == "\r":
+                escaped.append("\\r")
+            elif ch == "\t":
+                escaped.append("\\t")
+            elif ord(ch) < 32 or ord(ch) == 127:
+                escaped.append(f"\\x{ord(ch):02x}")
+            else:
+                escaped.append(ch)
+        return "$'" + "".join(escaped) + "'"
     return shlex.quote(value)
 
 def emit_var(name: str, value: Any) -> None:

--- a/modules/profile_parser.py
+++ b/modules/profile_parser.py
@@ -16,6 +16,8 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 # Pre-compiled regexes
 RE_NON_ALPHANUM_UNDERSCORE = re.compile(r'[^A-Za-z0-9_]')
 RE_DASH_SEQ = re.compile(r'-+')
+RE_SHELL_NAME = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+RE_SIMPLE_SHELL_TOKEN = re.compile(r'^[A-Za-z0-9_@%+=:,./-]+$')
 
 # Regex for stripping inline comments
 # We scan for Quotes and Hashes. Everything else is ignored.
@@ -342,36 +344,39 @@ def emit(line: str) -> None:
     sys.stdout.write(f"{line}\n")
 
 def shell_quote(value: str) -> str:
-    """Return one Bash-safe token without emitting physical newlines.
+    """Return exactly one Bash-safe word without physical newlines.
 
-    The Bash loader validates and evaluates parser output one line at a time.
-    ``shlex.quote`` preserves literal newlines, which turns one assignment into
-    several physical lines and breaks that contract. Bash ANSI-C quoting keeps
-    control characters escaped on one line and reconstructs them during eval.
+    Simple tokens remain unquoted. Every other value uses one ANSI-C quoted
+    word whose escape grammar is mirrored by ``profile::_ansi_c_word_is_safe``.
+    This avoids the multi-word quote concatenation produced by ``shlex.quote``
+    and keeps the line-wise loader contract auditable.
     """
     if "\x00" in value:
         raise ValueError("profile values cannot contain NUL bytes")
-    if any(ch in value for ch in "\n\r\t"):
-        escaped = []
-        for ch in value:
-            if ch == "\\":
-                escaped.append("\\\\")
-            elif ch == "'":
-                escaped.append("\\'")
-            elif ch == "\n":
-                escaped.append("\\n")
-            elif ch == "\r":
-                escaped.append("\\r")
-            elif ch == "\t":
-                escaped.append("\\t")
-            elif ord(ch) < 32 or ord(ch) == 127:
-                escaped.append(f"\\x{ord(ch):02x}")
-            else:
-                escaped.append(ch)
-        return "$'" + "".join(escaped) + "'"
-    return shlex.quote(value)
+    if RE_SIMPLE_SHELL_TOKEN.fullmatch(value):
+        return value
+
+    escaped = []
+    for ch in value:
+        if ch == "\\":
+            escaped.append("\\\\")
+        elif ch == "'":
+            escaped.append("\\'")
+        elif ch == "\n":
+            escaped.append("\\n")
+        elif ch == "\r":
+            escaped.append("\\r")
+        elif ch == "\t":
+            escaped.append("\\t")
+        elif ord(ch) < 32 or ord(ch) == 127:
+            escaped.append(f"\\x{ord(ch):02x}")
+        else:
+            escaped.append(ch)
+    return "$'" + "".join(escaped) + "'"
 
 def emit_var(name: str, value: Any) -> None:
+    if not RE_SHELL_NAME.fullmatch(name):
+        raise ValueError(f"invalid shell variable name: {name!r}")
     sval = '' if value is None else str(value)
     emit(f"{name}={shell_quote(sval)}")
 
@@ -382,6 +387,8 @@ def emit_env(prefix: str, mapping: Any) -> None:
         if key is None:
             continue
         skey = str(key)
+        if not RE_SHELL_NAME.fullmatch(skey):
+            raise ValueError(f"invalid environment key: {skey!r}")
         emit_var(f"{prefix}_{skey}", val)
 
 def emit_caps(caps: Any) -> None:

--- a/tests/guard_integrity.bats
+++ b/tests/guard_integrity.bats
@@ -38,7 +38,7 @@ teardown() {
   touch artifacts/integrity/forbidden.file
   git add artifacts/integrity/forbidden.file 2>/dev/null || true
 
-  run wgx guard
+  run wgx guard --only integrity
   assert_failure
   assert_output --regexp "artifacts/integrity/ is [Ff]orbidden"
 }
@@ -46,7 +46,7 @@ teardown() {
 @test "guard integrity: WARNS when reports/integrity/ exists but summary.json is missing" {
   mkdir -p reports/integrity
 
-  run wgx guard
+  run wgx guard --only integrity
   assert_success
   assert_output --partial "Integrity task detected but no reports/integrity/summary.json produced."
 }
@@ -64,7 +64,7 @@ wgx:
     lint: "echo lint"
 EOF
 
-  run wgx guard
+  run wgx guard --only integrity
   assert_success
   assert_output --partial "Integrity task detected but no reports/integrity/summary.json produced."
 }
@@ -74,7 +74,7 @@ EOF
   touch reports/integrity/summary.json
   echo '{"url": "https://example.com", "generated_at": "2024-01-01T00:00:00Z", "repo": "r", "status": "OK", "extra": "x"}' > reports/integrity/event_payload.json
 
-  run wgx guard
+  run wgx guard --only integrity
   assert_failure
   assert_output --regexp "Event payload contains [Ff]orbidden keys: extra"
 }
@@ -84,7 +84,7 @@ EOF
   touch reports/integrity/summary.json
   echo '{"url": "https://example.com", "generated_at": "2024-01-01T00:00:00Z", "repo": "r", "status": "OK", "counts": {"foo": 1}}' > reports/integrity/event_payload.json
 
-  run wgx guard
+  run wgx guard --only integrity
   assert_failure
   assert_output --regexp "Event payload contains [Ff]orbidden keys: counts" # Regex match for forbidden/Forbidden
 }
@@ -94,7 +94,7 @@ EOF
   touch reports/integrity/summary.json
   echo '{"url": "https://example.com", "generated_at": "2024-01-01T00:00:00Z", "repo": "r", "status": "OK"}' > reports/integrity/event_payload.json
 
-  run wgx guard
+  run wgx guard --only integrity
   assert_success
   assert_output --partial "Running integrity guard..."
   assert_output --partial "Integrity checks passed."
@@ -103,7 +103,7 @@ EOF
 @test "guard integrity: PASSES when artifacts/integrity exists but is empty" {
   mkdir -p artifacts/integrity
 
-  run wgx guard
+  run wgx guard --only integrity
   assert_success
   # Should not fail with forbidden message
   [[ ! "$output" =~ "artifacts/integrity/ is forbidden" ]]
@@ -114,7 +114,7 @@ EOF
   touch reports/integrity/summary.json
   echo '{"generated_at": "2024-01-01T00:00:00Z", "repo": "r", "status": "OK"}' > reports/integrity/event_payload.json
 
-  run wgx guard
+  run wgx guard --only integrity
   assert_failure
   assert_output --partial "Event payload missing mandatory key: url"
 }
@@ -124,7 +124,7 @@ EOF
   touch reports/integrity/summary.json
   echo '{"url": "https://example.com", "generated_at": "2024-01-01T00:00:00Z", "repo": "r"}' > reports/integrity/event_payload.json
 
-  run wgx guard
+  run wgx guard --only integrity
   assert_failure
   assert_output --partial "Event payload missing mandatory key: status"
 }
@@ -134,7 +134,7 @@ EOF
   touch reports/integrity/summary.json
   echo '"not-an-object"' > reports/integrity/event_payload.json
 
-  run wgx guard
+  run wgx guard --only integrity
   assert_failure
   assert_output --partial "Event payload must be an object."
 }
@@ -143,7 +143,7 @@ EOF
   mkdir -p reports/integrity
   echo '{"url": "https://example.com", "generated_at": "2024-01-01T00:00:00Z", "repo": "r", "status": "OK"}' > reports/integrity/event_payload.json
 
-  run wgx guard
+  run wgx guard --only integrity
   assert_success
   assert_output --partial "WARN: Integrity task detected but no reports/integrity/summary.json produced."
   # Should still validate event_payload.json and pass
@@ -155,7 +155,7 @@ EOF
   touch reports/integrity/summary.json
   echo '{"url": "https://example.com/other.json", "generated_at": "2024-01-01T00:00:00Z", "repo": "r", "status": "OK"}' > reports/integrity/event_payload.json
 
-  run wgx guard
+  run wgx guard --only integrity
   assert_success
   assert_output --partial "WARN: Event payload.url does not appear to point to a 'summary.json' report"
   assert_output --partial "Integrity checks passed."
@@ -194,7 +194,7 @@ EOF
   touch reports/integrity/summary.json
   echo '{"url": "https://example.com", "generated_at": "2024-01-01T00:00:00Z", "repo": "r", "status": "INVALID"}' > reports/integrity/event_payload.json
 
-  run wgx guard
+  run wgx guard --only integrity
   assert_failure
   assert_output --partial "Event payload.status must be one of: OK, WARN, FAIL, MISSING, UNCLEAR"
 }
@@ -204,7 +204,7 @@ EOF
   touch reports/integrity/summary.json
   echo '{"url": "ftp://example.com", "generated_at": "2024-01-01T00:00:00Z", "repo": "r", "status": "OK"}' > reports/integrity/event_payload.json
 
-  run wgx guard
+  run wgx guard --only integrity
   assert_failure
   assert_output --partial "Event payload.url must be a valid HTTP/HTTPS URL"
 }
@@ -214,7 +214,7 @@ EOF
   touch reports/integrity/summary.json
   echo '{"url": "https://example.com", "generated_at": "invalid-date", "repo": "r", "status": "OK"}' > reports/integrity/event_payload.json
 
-  run wgx guard
+  run wgx guard --only integrity
   assert_failure
   assert_output --partial "Event payload.generated_at must be in ISO-8601 format"
 }
@@ -224,7 +224,7 @@ EOF
   touch reports/integrity/summary.json
   echo '{"url": "https://example.com", "generated_at": "2024-01-01T00:00:00Z", "repo": "", "status": "OK"}' > reports/integrity/event_payload.json
 
-  run wgx guard
+  run wgx guard --only integrity
   assert_failure
   assert_output --partial "Event payload.repo must be a non-empty string."
 }
@@ -234,13 +234,13 @@ EOF
   touch reports/integrity/summary.json
   # url is number
   echo '{"url": 123, "generated_at": "2024-01-01T00:00:00Z", "repo": "r", "status": "OK"}' > reports/integrity/event_payload.json
-  run wgx guard
+  run wgx guard --only integrity
   assert_failure
   assert_output --partial "Event payload.url must be a string."
 
   # status is number
   echo '{"url": "https://a.com/summary.json", "generated_at": "2024-01-01T00:00:00Z", "repo": "r", "status": 123}' > reports/integrity/event_payload.json
-  run wgx guard
+  run wgx guard --only integrity
   assert_failure
   assert_output --partial "Event payload.status must be a string."
 }

--- a/tests/profile_tasks.bats
+++ b/tests/profile_tasks.bats
@@ -158,3 +158,30 @@ SH
   assert_line --index 3 -- "single_hash_cmd=STR:echo 'keep # single'"
   assert_line --index 4 -- "double_hash_cmd=STR:echo \"keep # double\" '#stay literal'"
 }
+
+
+@test "parser assignment safety rejects concatenated ANSI-C words before eval" {
+  marker="$BATS_TEST_TMPDIR/parser-eval-pwned"
+  helper_script="$BATS_TEST_TMPDIR/check_parser_assignment_safety.sh"
+  cat >"$helper_script" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+REPO_ROOT="$1"
+MARKER="$2"
+LINE="$3"
+source "$REPO_ROOT/lib/core.bash"
+source "$REPO_ROOT/modules/profile.bash"
+if profile::_apply_parser_line "$LINE"; then
+  echo "unsafe line was accepted" >&2
+  exit 10
+fi
+[[ ! -e "$MARKER" ]]
+SH
+  chmod +x "$helper_script"
+
+  quoted_marker="$(printf '%q' "$marker")"
+  malicious_line="WGX_ENV_BASE_MAP_FOO=\$'x'\$(touch ${quoted_marker})\$'y'"
+  run "$helper_script" "$REPO_ROOT" "$marker" "$malicious_line"
+  assert_success
+  [[ ! -e "$marker" ]]
+}

--- a/tests/test_profile_parser.py
+++ b/tests/test_profile_parser.py
@@ -4,7 +4,9 @@ import os
 import io
 import unittest
 import tempfile
+import subprocess
 from unittest.mock import patch, mock_open
+from pathlib import Path
 
 from modules import profile_parser
 
@@ -101,6 +103,49 @@ class TestProfileParser(unittest.TestCase):
         """Test comments at start of line."""
         self.assertEqual(profile_parser._strip_inline_comment("# comment"), "")
         self.assertEqual(profile_parser._strip_inline_comment("   # comment"), "   ")
+
+    def test_shell_quote_multiline_is_one_line_and_round_trips(self):
+        value = "echo one\nprintf '%s\n' 'two'\necho $(literal)"
+
+        quoted = profile_parser.shell_quote(value)
+
+        self.assertNotIn("\n", quoted)
+        self.assertTrue(quoted.startswith("$'"))
+        completed = subprocess.run(
+            ["bash", "-c", f"value={quoted}; printf %s \"$value\""],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.stdout, value)
+
+    def test_profile_loader_runs_multiline_task_with_single_quotes(self):
+        root = Path(__file__).resolve().parents[1]
+        content = (
+            "tasks:\n"
+            "  smoke: |\n"
+            "    printf '%s\\n' one\n"
+            "    printf '%s\\n' 'two words'\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            profile_dir = Path(tmp_dir) / ".wgx"
+            profile_dir.mkdir()
+            (profile_dir / "profile.yml").write_text(content, encoding="utf-8")
+            script = (
+                "set -euo pipefail; "
+                f"source {profile_parser.shell_quote(str(root / 'lib' / 'core.bash'))}; "
+                f"source {profile_parser.shell_quote(str(root / 'modules' / 'profile.bash'))}; "
+                f"cd {profile_parser.shell_quote(tmp_dir)}; "
+                "WGX_PROFILE_DEPRECATION=quiet; export WGX_PROFILE_DEPRECATION; "
+                "profile::load .wgx/profile.yml; profile::run_task smoke"
+            )
+            completed = subprocess.run(
+                ["bash", "-c", script],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(completed.stdout, "one\ntwo words\n")
 
     def test_main_missing_args(self):
         """Test that main() exits with status 1 if arguments are missing."""

--- a/tests/test_profile_parser.py
+++ b/tests/test_profile_parser.py
@@ -119,6 +119,35 @@ class TestProfileParser(unittest.TestCase):
         )
         self.assertEqual(completed.stdout, value)
 
+    def test_shell_quote_uses_one_ansi_c_word_for_unsafe_values(self):
+        for value in ("", "two words", "it's safe", "$(literal)"):
+            quoted = profile_parser.shell_quote(value)
+            self.assertTrue(quoted.startswith("$'"), quoted)
+            self.assertTrue(quoted.endswith("'"), quoted)
+            self.assertNotIn("'\"'\"'", quoted)
+
+    def test_simple_token_with_plus_equals_round_trips(self):
+        quoted = profile_parser.shell_quote("foo+=bar")
+        self.assertEqual(quoted, "foo+=bar")
+        completed = subprocess.run(
+            ["bash", "-c", f"source modules/profile.bash; profile::_apply_parser_line 'VALUE={quoted}'; printf %s \"$VALUE\""],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.stdout, "foo+=bar")
+
+    def test_emit_var_rejects_invalid_shell_name(self):
+        with self.assertRaisesRegex(ValueError, "invalid shell variable name"):
+            profile_parser.emit_var("WGX_SAFE=$(touch /tmp/nope)", "value")
+
+    def test_emit_env_rejects_invalid_environment_key(self):
+        with self.assertRaisesRegex(ValueError, "invalid environment key"):
+            profile_parser.emit_env(
+                "WGX_ENV_BASE_MAP",
+                {"SAFE=$'x'$(touch /tmp/nope)$'y'": "value"},
+            )
+
     def test_profile_loader_runs_multiline_task_with_single_quotes(self):
         root = Path(__file__).resolve().parents[1]
         content = (


### PR DESCRIPTION
## Zweck

Schafft den dauerhaft in `main` liegenden Parser-Prerequisite für den wiederverwendbaren WGX-Smoke aus PR #637.

## Änderungen

- erhält mehrzeilige Taskwerte als genau eine physische Bash-Zuweisungszeile;
- emittiert unsichere Werte als genau ein streng definiertes ANSI-C-Wort;
- validiert Variablennamen und Environment-Keys;
- verwirft NUL, Wortverkettungen, Expansionen, Separatoren und nicht erlaubte Escapes vor `eval`;
- begrenzt Integritäts-Unit-Tests auf `wgx guard --only integrity`, um rekursive Gesamtsuiten unter altem Bats zu verhindern.

## Gebundene Evidenz

- Base: `3d823f9d26be276eef97742335dee857a64e1715`
- Head: `4b688c8c06dcb895312fa222f4bf047ccfb6da0c`
- Diff SHA-256: `1304cd8024dd8168944e8227532c18dfb551ba5c7af6cfed7ec817da9ad63882`
- risikogewichteter Selbstreview: **PASS**

## Lokale Validierung

- 77 Python-Tests;
- 18 Integritäts-Bats;
- 4 Profil-Task-Bats;
- Profil-State-, Run-, Tasks- und Guard-Suiten;
- `bash -n`, `shellcheck`, `shfmt`, `git diff --check`.

## Abhängigkeit

Dieser PR muss vor PR #637 per Merge-Commit integriert werden. Danach wird #637 auf den gemergten Parser-Head neu aufgebaut und pinnt den wiederverwendbaren Smoke auf diesen dauerhaft erreichbaren Commit.
