### PR TITLE
fix(ci): advance pinned observatory workflow

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -65,6 +65,6 @@ jobs:
           fi
 
   validate-observatory:
-    uses: heimgewebe/metarepo/.github/workflows/reusable-validate-observatory.yml@8a509b1da5e3b13b2f0d444227d0c5e3b6805a0a
+    uses: heimgewebe/metarepo/.github/workflows/reusable-validate-observatory.yml@dda0d036b3b4db935d3acbaa4c1b0fc76637cea9  # metarepo PR #647 merge 2026-07-12
     permissions:
       contents: read


### PR DESCRIPTION
## Kontext

Der wiederverwendbare WGX-Guard zeigte noch auf metarepo `8a509b1…`. Dessen `reusable-validate-observatory.yml` enthielt zwei bewegliche Action-Tags. Metarepo PR #647 hat diese Tags gepinnt und ist als `dda0d036…` vollständig grün gemergt.

## Änderung

- den WGX-Observatory-Aufruf auf den gehärteten metarepo-Merge `dda0d036b3b4db935d3acbaa4c1b0fc76637cea9` weiterstellen

## Prüfung

- WGX-Pin-Checker — grün
- Workflowparser — grün
- 9 fokussierte Bats-Vertragstests — grün
- 72 unittest-Tests und 77 pytest-Tests — grün
- Bash-Syntax für 54 Dateien — grün
- vollständige lokale Bats-Suite: dieselben 58 bekannten Umgebungs-/Baselinefehler wie unverändertes `origin/main`, keine zusätzliche Abweichung

## Review-Grenze

Der PR ändert nur einen unveränderlichen Workflowverweis. Er beweist weder Schadcodefreiheit der gepinnten Commits noch vollständige metarepo-/WGX-weite Abhängigkeitshärtung außerhalb dieser erreichten Kette.
