### PR TITLE
fix(profile): validate quoted task values structurally

### DIFF
--- a/modules/profile.bash
+++ b/modules/profile.bash
@@ -195,10 +195,10 @@ profile::_parser_line_is_safe() {
   [[ -n $line ]] || return 0
   [[ ${line:0:1} == "#" ]] && return 0
 
-  # hard reject obvious non-bash / python-ish tokens (fast fail, better error)
-  if [[ $line == *"try:"* || $line == *"except"* || $line == import\ * || $line == *"sys.exit"* || $line == *"print("* ]]; then
-    return 1
-  fi
+  # Parse the assignment shape before inspecting its value. Parser-emitted
+  # values are data: a complete ANSI-C-quoted word may legitimately contain
+  # tokens such as ``print(`` or ``import`` without making them executable.
+  # Raw commands and concatenated shell words are still rejected below.
 
   # Accept only the two assignment forms emitted by profile_parser.py.
   # Capturing the operator next to the variable name avoids mistaking a value

--- a/tests/profile_tasks.bats
+++ b/tests/profile_tasks.bats
@@ -185,3 +185,37 @@ SH
   assert_success
   [[ ! -e "$marker" ]]
 }
+
+@test "parser assignment safety rejects executable and malformed lines before eval" {
+  marker="$BATS_TEST_TMPDIR/parser-eval-multi-pwned"
+  helper_script="$BATS_TEST_TMPDIR/check_parser_assignment_matrix.sh"
+  cat >"$helper_script" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+REPO_ROOT="$1"
+MARKER="$2"
+LINE="$3"
+source "$REPO_ROOT/lib/core.bash"
+source "$REPO_ROOT/modules/profile.bash"
+if profile::_apply_parser_line "$LINE"; then
+  echo "unsafe line was accepted: $LINE" >&2
+  exit 10
+fi
+[[ ! -e "$MARKER" ]]
+SH
+  chmod +x "$helper_script"
+
+  quoted_marker="$(printf '%q' "$marker")"
+  unsafe_lines=(
+    "WGX_VALUE=\$(touch ${quoted_marker})"
+    'WGX_VALUE=${HOME}'
+    "WGX_VALUE=ok;touch ${quoted_marker}"
+    "print('x')"
+    "WGX_VALUE=\$'unterminated"
+  )
+  for line in "${unsafe_lines[@]}"; do
+    run "$helper_script" "$REPO_ROOT" "$marker" "$line"
+    assert_success
+    [[ ! -e "$marker" ]]
+  done
+}

--- a/tests/test_profile_parser.py
+++ b/tests/test_profile_parser.py
@@ -176,6 +176,51 @@ class TestProfileParser(unittest.TestCase):
             )
         self.assertEqual(completed.stdout, "one\ntwo words\n")
 
+    def test_profile_loader_accepts_python_tokens_inside_quoted_task_value(self):
+        root = Path(__file__).resolve().parents[1]
+        content = (
+            "wgx:\n"
+            "  tasks:\n"
+            "    smoke: |\n"
+            "      python3 - <<'PY'\n"
+            "      import os\n"
+            "      try:\n"
+            "          print(os.environ.get('HOME'))\n"
+            "      except Exception:\n"
+            "          raise\n"
+            "      PY\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            profile_dir = Path(tmp_dir) / ".wgx"
+            profile_dir.mkdir()
+            (profile_dir / "profile.yml").write_text(content, encoding="utf-8")
+            script = (
+                "set -euo pipefail; "
+                f"source {profile_parser.shell_quote(str(root / 'lib' / 'core.bash'))}; "
+                f"source {profile_parser.shell_quote(str(root / 'modules' / 'profile.bash'))}; "
+                f"cd {profile_parser.shell_quote(tmp_dir)}; "
+                "WGX_PROFILE_DEPRECATION=quiet; export WGX_PROFILE_DEPRECATION; "
+                "profile::load .wgx/profile.yml; printf %s \"${WGX_TASK_CMDS[smoke]}\""
+            )
+            completed = subprocess.run(
+                ["bash", "-c", script],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        expected = (
+            "STR:python3 - <<'PY'\n"
+            "import os\n"
+            "try:\n"
+            "    print(os.environ.get('HOME'))\n"
+            "except Exception:\n"
+            "    raise\n"
+            "PY\n"
+        )
+        self.assertEqual(completed.stdout, expected)
+        self.assertIn("print(", completed.stdout)
+        self.assertIn("import os", completed.stdout)
+
     def test_main_missing_args(self):
         """Test that main() exits with status 1 if arguments are missing."""
         with patch.object(sys, 'argv', ['profile_parser.py']):


### PR DESCRIPTION
## Problem

Die Parser-Sicherheitsprüfung verwirft Tokens wie `print(`, `import`, `try:` oder `except` bereits auf der gesamten Zuweisungszeile. Dadurch wird auch ein vollständig ANSI-C-quotierter, parsergenerierter Taskwert als ausführbarer Code fehlklassifiziert. Chroniks unverändertes Smoke-Profil scheitert deshalb dauerhaft, obwohl der Wert nur Daten für eine spätere Taskausführung ist.

## Änderung

- Zuweisungsform und Wertquotierung werden zuerst strukturell validiert.
- Ein einzelnes vollständiges ANSI-C-quotiertes Wort darf beliebigen Dateninhalt enthalten.
- Rohbefehle, Expansionen, Command Substitution, Semikolon-Ausführung, verkettete Shell-Wörter und fehlerhafte Quotes bleiben gesperrt.
- Regressionstest mit Python-Heredoc und Negativmatrix ergänzt.

## Belege

- 73 Python-Unittests bestanden.
- `tests/profile_tasks.bats`: 5/5 bestanden.
- exakter unveränderter Chronik-Stand `16474d542e61e42bc7533d6b575bf243c6a496f2`: `wgx tasks --json` und `wgx task smoke` bestanden.
- `bash -n`, CI-identisches `shfmt -d` und ShellCheck bestanden.
- vollständige Bats-Suite: alle parserbezogenen Tests bestanden; drei `contracts_ownership`-Fehler sind auf unverändertem WGX-main identisch reproduzierbar. Ein `clean --deep`-Test ist nur in dirty Patch-Worktrees erwartungsgemäß rot und auf sauberem main grün.

## Sicherheitsgrenze

Der Patch führt keine neue Eval-Form ein. `eval` erhält weiterhin ausschließlich einen validierten Variablennamen und entweder einen einfachen Token oder genau ein vollständig geprüftes ANSI-C-quotiertes Wort.