### PR TITLE
fix(ci): pin smoke to quoted-value parser fix

### DIFF
--- a/.github/workflows/wgx-smoke.yml
+++ b/.github/workflows/wgx-smoke.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           repository: heimgewebe/wgx
-          ref: 4b688c8c06dcb895312fa222f4bf047ccfb6da0c
+          ref: 3c2391623a1719ac5f0dd1cda6ba906b94079053
           path: .wgx-cli
           persist-credentials: false
 

--- a/scripts/check_wgx_smoke_contract.py
+++ b/scripts/check_wgx_smoke_contract.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 DEFAULT_WORKFLOW = Path(".github/workflows/wgx-smoke.yml")
-PINNED_CLI_COMMIT = "4b688c8c06dcb895312fa222f4bf047ccfb6da0c"
+PINNED_CLI_COMMIT = "3c2391623a1719ac5f0dd1cda6ba906b94079053"
 PY_YAML_WHEEL_SHA256 = "ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc"
 
 


### PR DESCRIPTION
## Zweck

Der wiederverwendbare WGX-Smoke lädt weiterhin Parser-Commit `4b688c8…`. Damit würden Downstream-Repositories trotz des gemergten Parserfixes aus PR #640 die fehlerhafte Fassung ausführen.

## Änderung

- CLI-Pin in `.github/workflows/wgx-smoke.yml` auf den gemergten Commit `3c2391623a1719ac5f0dd1cda6ba906b94079053` angehoben.
- Der maschinenlesbare Smoke-Vertragsprüfer auf denselben unveränderlichen Commit gebunden.

## Prüfung

- Smoke-Vertrag: PASS
- externe Action-Pins: PASS
- Workflow-Syntax: PASS
- `tests/wgx_guard_action_pins.bats`: 9/9 bestanden
- `git diff --check`: PASS

Der PR enthält ausschließlich zwei identische SHA-Aktualisierungen und keine ausführbare Logikänderung.