### PR TITLE
docs: source system context from Systemkatalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,18 +436,14 @@ Seit 2025-09-25 ist die modulare Struktur verbindlich (`cli/`, `cmd/`, `lib/`,
 `etc/`, `modules/`). Der alte Monolith wurde archiviert:
 `docs/archive/wgx_monolith_*.md`.
 
-## Organismus-Kontext
+## Systemkontext
 
-Dieses Repository ist Teil des **Heimgewebe-Organismus**.
+Der aktuelle Zweck, Lifecycle-Status und die Beziehungen dieses Repositories zu anderen
+Heimgewebe-Systemen werden im [Systemkatalog](https://github.com/heimgewebe/systemkatalog) geführt. Die
+[gerenderte Systemübersicht](https://github.com/heimgewebe/systemkatalog/blob/main/rendered/system-catalog.md)
+ist die lesbare Gesamtsicht; die
+[maschinenlesbare Inventur](https://github.com/heimgewebe/systemkatalog/blob/main/registry/ecosystem/nodes.json)
+ist die Quelle für Automatisierung.
 
-Die übergeordnete Architektur, Achsen, Rollen und Contracts sind zentral
-beschrieben im
-👉 [`metarepo/docs/system/heimgewebe-organismus.md`][organismus]
-sowie im Zielbild
-👉 [`metarepo/docs/system/heimgewebe-zielbild.md`][zielbild].
-
-[organismus]: https://github.com/heimgewebe/metarepo/blob/main/docs/system/heimgewebe-organismus.md
-[zielbild]: https://github.com/heimgewebe/metarepo/blob/main/docs/system/heimgewebe-zielbild.md
-
-Alle Rollen-Definitionen, Datenflüsse und Contract-Zuordnungen dieses Repos
-sind dort verankert.
+Repositoryeigene Betriebs-, Daten- und Implementierungswahrheit bleibt in diesem Repository.
+Gemeinsame Contracts bleiben bei ihrer jeweiligen Primärquelle.


### PR DESCRIPTION
## Zweck

WGX soll aktuelle Systemzwecke und Beziehungen nicht aus historisierten Metarepo-Seiten ableiten.

## Änderung

- README-Systemkontext auf Systemkatalog umgestellt
- alte Metarepo-Organismus- und Zielbildlinks entfernt
- repositoryeigene Betriebs- und Implementierungswahrheit lokal belassen

## Prüfung

- Markdownlint ohne Fehler
- 22 README-Links einschließlich aller Systemkatalog-Ziele bestanden
- T006-Drift-, Ziel- und Whitespace-Gate bestanden

## Unabhängiger Bestandsbefund

Das bestehende `Justfile` auf `origin/main` lässt sich wegen zusätzlicher Einrückung in Zeile 16 nicht parsen. T006 ändert das Justfile nicht; der Defekt wird separat im Bureau registriert.

Bureau: `METAREPO-LEGACY-RECONCILIATION-V1-T006`