### PR TITLE
fix(ci): isolate Vale archive extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,12 +445,14 @@ jobs:
             exit 1
           fi
 
-          tar -xzf vale.tar.gz
-          test -f vale && echo "vale binary extracted" || (echo "vale missing" && exit 1)
-          sudo install -m 0755 vale /usr/local/bin/vale
+          extract_dir=$(mktemp -d)
+          tar -xzf vale.tar.gz -C "$extract_dir"
+          test -f "$extract_dir/vale" && echo "vale binary extracted" || (echo "vale missing" && exit 1)
+          sudo install -m 0755 "$extract_dir/vale" /usr/local/bin/vale
           echo "Installed Vale ${version} (${asset_name})"
           vale --version
-          rm -f vale vale.tar.gz checksums.txt
+          rm -rf "$extract_dir"
+          rm -f vale.tar.gz checksums.txt
       - name: Markdownlint (changed only)
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Ursache

Der Docs-Job entpackt das Vale-Releasearchiv direkt ins Repository. Das checksumgeprüfte Archiv `vale_2.27.0_Linux_64-bit.tar.gz` enthält `LICENSE`, `README.md` und `vale`; dadurch werden vor Markdownlint die WGX-Dateien `README.md` und `LICENSE` überschrieben.

Das erklärt den roten Docs-Job in PR #642: Checkout und Merge-Ref waren korrekt, Markdownlint prüfte anschließend jedoch die Vale-README.

## Änderung

- Archiv in ein temporäres Verzeichnis entpacken
- Vale-Binary ausschließlich daraus installieren
- temporäres Verzeichnis entfernen
- Repositorydateien nicht mehr überschreiben

## Prüfung

- Archiv-SHA-256 entspricht dem CI-Beleg: `876e60b267e914f2e5c4d7088dc8fa7b4c3156833b3b883342a07b22a52f7255`
- Archivinhalt belegt: `LICENSE`, `README.md`, `vale`
- Regressionstest: Repository-README bleibt hashgleich; Vale-Binary liegt im Extraktionsverzeichnis
- Workflow-YAML gültig
- `git diff --check` grün

Blockiert: `heimgewebe/wgx#642`