### PR TITLE
fix: align Justfile shell formatting lint with CI

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -27,5 +27,5 @@ lint:
     mapfile -d '' files < <(git ls-files -z -- '*.sh' '*.bash' || true); \
     if [ "${#files[@]}" -eq 0 ]; then echo "keine Shell-Dateien"; exit 0; fi; \
     printf '%s\0' "${files[@]}" | xargs -0 bash -n; \
-    shfmt -d -i 2 -ci -sr -- "${files[@]}"; \
+    shfmt -d -- "${files[@]}"; \
     shellcheck -S style -- "${files[@]}"

--- a/tests/shell_ci.bats
+++ b/tests/shell_ci.bats
@@ -67,6 +67,12 @@ SCRIPT
     run grep -F "$pattern" "$REPO_ROOT/.github/workflows/ci.yml"
     assert_success
   done
+
+  run grep -F 'shfmt -d -- "${files[@]}"' "$REPO_ROOT/Justfile"
+  assert_success
+
+  run grep -F 'shfmt -d -i 2 -ci -sr' "$REPO_ROOT/Justfile"
+  assert_failure
 }
 
 @test "assertion helper self-tests pass" {

--- a/tests/shell_ci.bats
+++ b/tests/shell_ci.bats
@@ -68,6 +68,9 @@ SCRIPT
     assert_success
   done
 
+  run grep -F 'shfmt -d "$file"' "$REPO_ROOT/.github/workflows/shell-docs.yml"
+  assert_success
+
   run grep -F 'shfmt -d -- "${files[@]}"' "$REPO_ROOT/Justfile"
   assert_success
 


### PR DESCRIPTION
## Zweck

Schließt `WGX-JUSTFILE-INTEGRITY-V1-T002`: Der lokale `just lint`-Pfad verwendete `shfmt -d -i 2 -ci -sr`, während beide GitHub-CI-Pfade und die dokumentierte Shell-CI-Baseline `shfmt -d` verwenden. Dadurch scheiterte ein sauberer aktueller `main` lokal an massenhaft vorbestehendem Format-Drift, obwohl der CI-Vertrag einen anderen Formatter-Stil prüft.

## Änderung

- `Justfile`: lokalen shfmt-Aufruf auf den bestehenden CI-Vertrag `shfmt -d` angleichen.
- `tests/shell_ci.bats`: Regressionstest bindet den Justfile-Aufruf an diesen Vertrag und verhindert die Rückkehr der abweichenden Flag-Kombination.
- Keine repositoryweite Massenformatierung.

## Evidenz

Basis: `ce503d6e72dc7609d559bde2a5f6970cb543e5d6`
Head: `48bb89c`

Grün:
- `just lint`
- `bats tests/shell_ci.bats` (3/3)
- nach Commit: `bats tests/clean.bats tests/shell_ci.bats` (11/11)
- `git diff --check`

Die vollständige lokale Suite `bats -r tests` enthält unabhängige Bestandsfehler in `guard_contracts_ownership`, `reload` und `routine_cmd`. Diese wurden auf einem separaten unveränderten Checkout von exakt `main` (`ce503d6e...`) reproduziert. Der während des dirty Feature-Checkouts zusätzlich beobachtete `clean --deep`-Fehler verschwand nach dem Commit und die `clean`-Suite ist danach vollständig grün.

## Grenze

Dieser PR ändert weder Shell-Quellformatierung noch Formatter-Policy in GitHub Actions. Er vereinheitlicht den lokalen Justfile-Lintvertrag mit der bereits dokumentierten und getesteten CI-Baseline.