### PR TITLE
fix: fetch canonical metrics schema before validation

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -9,7 +9,7 @@ on:
     - cron: "0 * * * *"
 
 env:
-  METRICS_SCHEMA_URL: https://raw.githubusercontent.com/heimgewebe/metarepo/contracts-v1/contracts/wgx/metrics.json
+  METRICS_SCHEMA_URL: https://raw.githubusercontent.com/heimgewebe/metarepo/b215b418a038ff535f07b7888fd6adeb3f4de51c/contracts/metrics.snapshot.schema.json
   HAUSKI_POST_URL: ${{ secrets.HAUSKI_METRICS_URL }}
 
 jobs:
@@ -40,7 +40,7 @@ jobs:
           curl -fsSL "$METRICS_SCHEMA_URL" -o .ci/metrics.schema.json
 
       - name: Validate metrics contract
-        run: npx --yes ajv-cli@5 validate -s .ci/metrics.schema.json -d metrics.json
+        run: npx --yes ajv-cli@5 validate --spec=draft2020 --strict=log -s .ci/metrics.schema.json -d metrics.json
 
       - name: Optional POST to hausKI
         if: ${{ env.HAUSKI_POST_URL && env.HAUSKI_POST_URL != '' }}

--- a/Justfile
+++ b/Justfile
@@ -9,7 +9,7 @@ devcontainer-check:
 devcontainer-install:
     .devcontainer/setup.sh install all
 
-export METRICS_SCHEMA_URL := "https://raw.githubusercontent.com/heimgewebe/metarepo/contracts-v1/contracts/wgx/metrics.json"
+export METRICS_SCHEMA_URL := "https://raw.githubusercontent.com/heimgewebe/metarepo/b215b418a038ff535f07b7888fd6adeb3f4de51c/contracts/metrics.snapshot.schema.json"
 
 wgx command *args:
     @scripts/just-dispatch.sh wgx "$@"

--- a/README.md
+++ b/README.md
@@ -130,9 +130,8 @@ stehen in [docs/readiness.md](docs/readiness.md). Ergänzend erklärt
 
   ```bash
   scripts/wgx-metrics-snapshot.sh --json --output metrics.json
-  SCHEMA="https://raw.githubusercontent.com/heimgewebe/metarepo"
-  SCHEMA="$SCHEMA/contracts-v1/contracts/wgx/metrics.json"
-  npx --yes ajv-cli@5 validate -s "$SCHEMA" -d metrics.json
+  SCHEMA="https://raw.githubusercontent.com/heimgewebe/metarepo/b215b418a038ff535f07b7888fd6adeb3f4de51c/contracts/metrics.snapshot.schema.json"
+  npx --yes ajv-cli@5 validate --spec=draft2020 --strict=log -s "$SCHEMA" -d metrics.json
   ```
 
 - Node.js tooling ist nicht erforderlich; npm-/pnpm-Workflows sind

--- a/scripts/just-dispatch.sh
+++ b/scripts/just-dispatch.sh
@@ -41,7 +41,23 @@ contracts)
   case "$action" in
   validate)
     : "${METRICS_SCHEMA_URL:?METRICS_SCHEMA_URL fehlt}"
-    exec npx --yes ajv-cli@5 validate -s "$METRICS_SCHEMA_URL" -d metrics.json "$@"
+    schema_path="$METRICS_SCHEMA_URL"
+    case "$METRICS_SCHEMA_URL" in
+    http://* | https://*)
+      schema_tmp_dir="$(mktemp -d)"
+      trap 'rm -rf "$schema_tmp_dir"' EXIT
+      schema_path="$schema_tmp_dir/metrics.schema.json"
+      if ! curl -fsSL "$METRICS_SCHEMA_URL" -o "$schema_path"; then
+        echo "contracts validate: Schema konnte nicht geladen werden: $METRICS_SCHEMA_URL" >&2
+        exit 1
+      fi
+      ;;
+    *://*)
+      echo "contracts validate: Nicht unterstützte Schema-URL: $METRICS_SCHEMA_URL" >&2
+      exit 2
+      ;;
+    esac
+    npx --yes ajv-cli@5 validate --spec=draft2020 --strict=log -s "$schema_path" -d metrics.json "$@"
     ;;
   *)
     echo "Unbekannter contracts-Befehl: $action" >&2

--- a/tests/contracts_validate.bats
+++ b/tests/contracts_validate.bats
@@ -1,0 +1,158 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  TEST_TMPDIR="$(mktemp -d)"
+  FAKE_BIN="$TEST_TMPDIR/bin"
+  mkdir -p "$FAKE_BIN" "$TEST_TMPDIR/tmp"
+  export REPO_ROOT TEST_TMPDIR FAKE_BIN
+  export TMPDIR="$TEST_TMPDIR/tmp"
+  export CURL_LOG="$TEST_TMPDIR/curl.args"
+  export NPX_LOG="$TEST_TMPDIR/npx.args"
+  export SCHEMA_PATH_LOG="$TEST_TMPDIR/schema.path"
+  export PATH="$FAKE_BIN:$PATH"
+
+  cat > "$FAKE_BIN/curl" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$CURL_LOG"
+if [[ "${FAKE_CURL_FAIL:-0}" == "1" ]]; then
+  echo "curl: (22) requested URL returned error: 503" >&2
+  exit 22
+fi
+output=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  -o | --output)
+    output=${2:-}
+    shift 2
+    ;;
+  *)
+    shift
+    ;;
+  esac
+done
+if [[ -z "$output" ]]; then
+  echo "fake curl: output path fehlt" >&2
+  exit 64
+fi
+printf '%s\n' '{"type":"object"}' > "$output"
+SCRIPT
+  chmod +x "$FAKE_BIN/curl"
+
+  cat > "$FAKE_BIN/npx" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$NPX_LOG"
+schema=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  -s)
+    schema=${2:-}
+    shift 2
+    ;;
+  *)
+    shift
+    ;;
+  esac
+done
+printf '%s\n' "$schema" > "$SCHEMA_PATH_LOG"
+if [[ "$schema" == "${METRICS_SCHEMA_URL:-}" && "$schema" == http*://* ]]; then
+  echo "error: Cannot find schema '$schema'" >&2
+  exit 2
+fi
+if [[ ! -f "$schema" ]]; then
+  echo "error: downloaded schema file missing: $schema" >&2
+  exit 3
+fi
+if [[ "${FAKE_NPX_SCHEMA_FAIL:-0}" == "1" ]]; then
+  echo "error: schema is invalid" >&2
+  exit 2
+fi
+SCRIPT
+  chmod +x "$FAKE_BIN/npx"
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+@test "contracts validate downloads remote schema instead of triggering Cannot find schema URL regression" {
+  export METRICS_SCHEMA_URL="https://example.invalid/contracts/metrics.json"
+
+  run "$REPO_ROOT/scripts/just-dispatch.sh" contracts validate
+
+  assert_success
+  run grep -Fx "$METRICS_SCHEMA_URL" "$CURL_LOG"
+  assert_success
+  schema_path="$(cat "$SCHEMA_PATH_LOG")"
+  [[ "$schema_path" != "$METRICS_SCHEMA_URL" ]]
+  [[ "$schema_path" == "$TMPDIR/"* ]]
+  [[ ! -e "$schema_path" ]]
+  run grep -Fx -- "--spec=draft2020" "$NPX_LOG"
+  assert_success
+  run grep -Fx -- "--strict=log" "$NPX_LOG"
+  assert_success
+}
+
+@test "contracts validate reports remote schema download failures and does not invoke ajv" {
+  export METRICS_SCHEMA_URL="https://example.invalid/contracts/metrics.json"
+  export FAKE_CURL_FAIL=1
+
+  run "$REPO_ROOT/scripts/just-dispatch.sh" contracts validate
+
+  assert_failure
+  assert_output --partial "curl: (22) requested URL returned error: 503"
+  assert_output --partial "contracts validate: Schema konnte nicht geladen werden: $METRICS_SCHEMA_URL"
+  [[ ! -e "$NPX_LOG" ]]
+}
+
+@test "contracts validate preserves ajv schema diagnostics" {
+  export METRICS_SCHEMA_URL="https://example.invalid/contracts/metrics.json"
+  export FAKE_NPX_SCHEMA_FAIL=1
+
+  run "$REPO_ROOT/scripts/just-dispatch.sh" contracts validate
+
+  [[ "$status" -eq 2 ]]
+  assert_output --partial "error: schema is invalid"
+}
+
+@test "contracts validate keeps explicit local schema paths supported without curl" {
+  local_schema="$TEST_TMPDIR/local.schema.json"
+  printf '%s\n' '{"type":"object"}' > "$local_schema"
+  export METRICS_SCHEMA_URL="$local_schema"
+
+  run "$REPO_ROOT/scripts/just-dispatch.sh" contracts validate
+
+  assert_success
+  [[ ! -e "$CURL_LOG" ]]
+  run grep -Fx "$local_schema" "$SCHEMA_PATH_LOG"
+  assert_success
+}
+
+@test "contracts validate rejects unsupported URL schemes explicitly" {
+  export METRICS_SCHEMA_URL="ftp://example.invalid/contracts/metrics.json"
+
+  run "$REPO_ROOT/scripts/just-dispatch.sh" contracts validate
+
+  [[ "$status" -eq 2 ]]
+  assert_output --partial "contracts validate: Nicht unterstützte Schema-URL: $METRICS_SCHEMA_URL"
+  [[ ! -e "$CURL_LOG" ]]
+  [[ ! -e "$NPX_LOG" ]]
+}
+
+
+@test "canonical metrics schema pin stays aligned across Justfile workflow and README" {
+  expected="https://raw.githubusercontent.com/heimgewebe/metarepo/b215b418a038ff535f07b7888fd6adeb3f4de51c/contracts/metrics.snapshot.schema.json"
+
+  run grep -F "export METRICS_SCHEMA_URL := \"$expected\"" "$REPO_ROOT/Justfile"
+  assert_success
+  run grep -F "METRICS_SCHEMA_URL: $expected" "$REPO_ROOT/.github/workflows/metrics.yml"
+  assert_success
+  run grep -F "SCHEMA=\"$expected\"" "$REPO_ROOT/README.md"
+  assert_success
+  run grep -F 'validate --spec=draft2020 --strict=log -s .ci/metrics.schema.json -d metrics.json' "$REPO_ROOT/.github/workflows/metrics.yml"
+  assert_success
+}


### PR DESCRIPTION
## Zweck

Schließt `WGX-JUSTFILE-INTEGRITY-V1-T003`: `just contracts validate` reichte bisher die konfigurierte Remote-Schema-URL direkt an `ajv-cli@5`, das sie als lokalen Dateipfad interpretierte (`Cannot find schema .../https:/...`). Zusätzlich zeigte der reale End-to-End-Test, dass die konfigurierte historische `contracts-v1/contracts/wgx/metrics.json`-Referenz selbst HTTP 404 liefert.

## Änderung

- Remote-Schemas (`http`/`https`) werden vor AJV in ein temporäres Verzeichnis geladen und nach dem Lauf per `EXIT`-Trap entfernt.
- Downloadfehler werden explizit als `contracts validate`-Fehler gemeldet; unbekannte URL-Schemata werden abgewiesen; lokale Schema-Pfade bleiben unterstützt.
- Der kanonische Contract wird commitgepinnt aus `heimgewebe/metarepo@b215b418a038ff535f07b7888fd6adeb3f4de51c:contracts/metrics.snapshot.schema.json` bezogen.
- Lokaler Dispatcher und Metrics-Workflow verwenden den kanonischen AJV-Vertrag `--spec=draft2020 --strict=log`.
- README, Justfile und Metrics-Workflow verwenden denselben Schema-Pin.
- Neue Regressionstests decken den früheren `Cannot find schema https://...`-Fehler, Downloadfehler, AJV-Diagnostik, lokale Pfade, unbekannte Schemata sowie Contract-Pin-Drift ab.

## Evidenz

Basis: `40d2c3ddc1bced1dd37ff4c3c2a7dd9940d72646`
Head: `2ee9db1`

Grün:
- `bats tests/contracts_validate.bats tests/metrics_snapshot.bats tests/shell_ci.bats` — 16/16
- `just lint`
- reale Kette: `scripts/wgx-metrics-snapshot.sh --output metrics.json` + `just contracts validate` → `metrics.json valid`
- `git diff --check`

Der reale AJV-Lauf meldet mit `--strict=log` erwartete Warnungen für die kanonischen Metadaten-Schlüssel `x-producers` und `x-consumers`, validiert den Payload aber erfolgreich.

## Grenze

Es wird kein eigenes Schema erfunden oder geforkt. Der PR repariert ausschließlich den Schema-Transport und richtet WGX auf den bereits in Metarepo dokumentierten kanonischen Metrics-Contract aus.