### PR TITLE
test: isolate WGX git fixtures from ambient config

### DIFF
--- a/tests/guard_contracts_ownership.bats
+++ b/tests/guard_contracts_ownership.bats
@@ -6,6 +6,11 @@ setup() {
     # Create a temporary directory for the repository
     TEST_DIR="$(mktemp -d)"
     cd "$TEST_DIR"
+
+    # Test identity and diff mode must not depend on the caller environment.
+    unset HG_REPO_NAME GITHUB_REPOSITORY CI GITHUB_BASE_REF GITHUB_EVENT_BEFORE
+    unset GIT_DIR GIT_WORK_TREE
+
     git init
     git config user.email "test@example.com"
     git config user.name "Test User"
@@ -41,7 +46,6 @@ teardown() {
     mkdir contracts
     touch contracts/foo.schema.json
     git add contracts/foo.schema.json
-    git commit -m "Add contract"
 
     run "$GUARD_SCRIPT"
     assert_failure
@@ -59,7 +63,6 @@ teardown() {
     mkdir contracts
     touch contracts/internal.schema.json
     git add fleet/repos.yml contracts/internal.schema.json
-    git commit -m "Add contract"
 
     run "$GUARD_SCRIPT"
     assert_success
@@ -75,7 +78,6 @@ teardown() {
     mkdir contracts
     touch contracts/internal.schema.json
     git add contracts/internal.schema.json
-    git commit -m "Add contract"
 
     run "$GUARD_SCRIPT"
     assert_failure
@@ -91,7 +93,6 @@ teardown() {
     mkdir contracts
     touch contracts/some.schema.json
     git add contracts/some.schema.json
-    git commit -m "Add contract"
 
     run "$GUARD_SCRIPT"
     assert_failure
@@ -107,7 +108,6 @@ teardown() {
     mkdir json
     touch json/external.schema.json
     git add json/external.schema.json
-    git commit -m "Add json file"
 
     run "$GUARD_SCRIPT"
     assert_success
@@ -127,7 +127,6 @@ teardown() {
     mkdir contracts
     touch contracts/internal.schema.json
     git add fleet/repos.yml contracts/internal.schema.json
-    git commit -m "Add contract"
 
     run "$GUARD_SCRIPT"
     assert_success

--- a/tests/reload.bats
+++ b/tests/reload.bats
@@ -23,7 +23,7 @@ setup() {
   git tag baseline >/dev/null
   mkdir -p ../remote && (cd ../remote && git init --bare --initial-branch=main >/dev/null 2>&1)
   git remote add origin ../remote
-  git push -u origin main >/dev/null
+  git -c core.hooksPath=/dev/null push -u origin main >/dev/null
   export WGX_DIR="$project_root"
   export PATH="$WGX_DIR/cli:$PATH"
 }

--- a/tests/routine_cmd.bats
+++ b/tests/routine_cmd.bats
@@ -42,7 +42,7 @@ setup() {
   echo "init" > README.md
   git add README.md
   git commit -m "init"
-  git push -u origin main
+  git -c core.hooksPath=/dev/null push -u origin main
 
   mkdir -p .wgx/out
 }


### PR DESCRIPTION
## Zweck

Schließt WGX-JUSTFILE-INTEGRITY-V1-T004: lokale Bats-Fixtures werden von ambienter Repository-Identität und benutzerweiten Git-Hooks isoliert, ohne produktive Guards oder Push-Schutzregeln zu verändern.

## Änderung

- Ownership-Fixtures löschen geerbte Repository-/CI-Identitätsvariablen und modellieren lokale Contract-Änderungen als staged changes.
- Reload- und Routine-Fixtures deaktivieren Git-Hooks ausschließlich für den initialen Push ihrer temporären Test-Repositories über `git -c core.hooksPath=/dev/null push`.
- Keine Änderung an produktiven Guard- oder Hook-Dateien.

## Reproduktion vor Fix

- vollständige lokale Bats-Suite: 13 T004-relevante Fehler
- davon 3 Ownership-, 3 Reload- und 7 Routine-Fixtures

## Validierung

- betroffene Suites: 17/17 grün
- vollständige lokale `bats -r tests`: 202/202 grün auf sauberem Commitzustand
- `just lint`: grün
- `git diff --check`: grün

## Evidenzgrenzen

Die Änderung isoliert Test-Fixtures. Sie schwächt keine produktiven Main-Push- oder Contracts-Ownership-Regeln und autorisiert keine Änderung dieser Regeln.